### PR TITLE
Upgrading cloudwatch_logs to use aws provider v4 like the other modules

### DIFF
--- a/modules/cloudwatch-logs/README.md
+++ b/modules/cloudwatch-logs/README.md
@@ -13,7 +13,7 @@ Manage the application which retrieves `CloudWatch` logs and sends them to your 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.15.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules

--- a/modules/cloudwatch-logs/versions.tf
+++ b/modules/cloudwatch-logs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.69"
+      version = ">= 4.15.1"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
In this repository there are 3 modules, and 2 of them use the (current) v4 branch of the aws provider.

Only cloudwatch_logs requires aws v3 and this prevents it being used in projects that have moved to v4 (many projects now).

I am in the process of testing this PoC, but this pull request simply updates the provider version with no other changes. The internal dependency on terraform-aws-modules supports both v3 and v4 and contains some logic which detects which is being used and acts appropriately, so I'm hopeful this works.

But feel free to run your tests or recreate this PR using your own processes, of course.