### PR TITLE
Add missing depends_on to subscription filters

### DIFF
--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -24,7 +24,7 @@ resource "random_string" "this" {
 }
 
 module "lambda" {
-  source                 = "terraform-aws-modules/lambda/aws"
+  source                 = "registry.terraform.io/terraform-aws-modules/lambda/aws"
   version                = "3.2.1"
 
   function_name          = local.function_name
@@ -63,6 +63,7 @@ module "lambda" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "this" {
+  depends_on      = [ module.lambda ] # Required for allowed_triggers (aws_lambda_permission) to be created before this filter is created.
   count           = length(var.log_groups)
   name            = "${module.lambda.lambda_function_name}-Subscription-${count.index}"
   log_group_name  = data.aws_cloudwatch_log_group.this[count.index].name

--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -64,10 +64,10 @@ module "lambda" {
 
 resource "aws_cloudwatch_log_subscription_filter" "this" {
 
-  # depends_on is required here for the above allowed_triggers
-  # (aws_lambda_permission resources) to be created before this filter.
-  # Otherwise the apply will often fail when there are multiple log_groups due
-  # to missing permissions.
+  # The depends_on is required here for the allowed_triggers in the above
+  # lambda module, which create aws_lambda_permission resources that are
+  # prerequisite for these aws_cloudwatch_log_subscription_filter resources, to
+  # finish applying before these start.
   depends_on      = [ module.lambda ]
 
   count           = length(var.log_groups)


### PR DESCRIPTION
Our pipelines were often failing (not always) because of the following error:

```hcl
│ Error: Error creating Cloudwatch log subscription filter: InvalidParameterException: Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.
│ 
│   with module.application_observability.module.cloudwatch_logs.aws_cloudwatch_log_subscription_filter.this[1],
│   on .terraform/modules/application_observability.cloudwatch_logs/modules/cloudwatch-logs/main.tf line 65, in resource "aws_cloudwatch_log_subscription_filter" "this":
│   65: resource "aws_cloudwatch_log_subscription_filter" "this" {
```

After some digging, I arrived at the theory that the `aws_cloudwatch_log_subscription_filter`s were being created before the prerequisite `aws_lambda_permission` resources stemming from the lambda module were finished creating. This could be an issue introduced by the multiple-log_groups feature recently added (which was otherwise a great improvement!).

Adding a single depends_on to the `aws_cloudwatch_log_subscription_filter` resources pointing to the lambda module makes them wait for the module to complete applying entirely before trying to create the filters. This seems to have fixed the issue we were having (very frequently).