### PR TITLE
Enable overrride the firehose default appname and subsystem labels

### DIFF
--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -31,7 +31,6 @@ locals {
     managed-by               = "coralogix-terraform"
   }
   application_name = var.application_name == null ? "coralogix-${var.firehose_stream}" : var.application_name
-  subsystem_name   = var.subsystem_name == null ? "cloudwatch_metrics" : var.subsystem_name
 }
 
 data "aws_caller_identity" "current_identity" {}
@@ -187,11 +186,6 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream" {
       common_attributes {
         name  = "applicationName"
         value = local.application_name
-      }
-
-      common_attributes {
-        name  = "subsystemName"
-        value = local.subsystem_name
       }
     }
   }

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -30,6 +30,8 @@ locals {
     terraform-module-version = "v0.0.1"
     managed-by               = "coralogix-terraform"
   }
+  application_name = var.application_name == null ? "coralogix-${var.firehose_stream}" : var.application_name
+  subsystem_name   = var.subsystem_name == null ? "cloudwatch_metrics" : var.subsystem_name
 }
 
 data "aws_caller_identity" "current_identity" {}
@@ -40,7 +42,7 @@ data "aws_region" "current_region" {}
 ################################################################################
 
 resource "aws_cloudwatch_log_group" "firehose_loggroup" {
-  tags        = local.tags
+  tags              = local.tags
   name              = "/aws/kinesisfirehose/${var.firehose_stream}"
   retention_in_days = 1
 }
@@ -180,6 +182,16 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream" {
       common_attributes {
         name  = "integrationType"
         value = var.integration_type
+      }
+
+      common_attributes {
+        name  = "applicationName"
+        value = local.application_name
+      }
+
+      common_attributes {
+        name  = "subsystemName"
+        value = local.subsystem_name
       }
     }
   }

--- a/modules/firehose/variables.tf
+++ b/modules/firehose/variables.tf
@@ -4,7 +4,7 @@ variable "firehose_stream" {
 }
 
 variable "privatekey" {
-  description = "Coralogix account logs private key"
+  description = "Coralogix account private key"
   sensitive   = true
 
 }
@@ -41,4 +41,16 @@ variable "integration_type" {
   description = "The integration type of the firehose delivery stream: 'CloudWatch_Metrics_JSON' or 'CloudWatch_Metrics_OpenTelemetry070'"
   type        = string
   default     = "CloudWatch_Metrics_OpenTelemetry070"
+}
+
+variable "application_name" {
+  description = "The application name of the metrics"
+  type        = string
+  default     = null
+}
+
+variable "subsystem_name" {
+  description = "The subsystem name of the metrics"
+  type        = string
+  default     = null
 }

--- a/modules/firehose/variables.tf
+++ b/modules/firehose/variables.tf
@@ -48,9 +48,3 @@ variable "application_name" {
   type        = string
   default     = null
 }
-
-variable "subsystem_name" {
-  description = "The subsystem name of the metrics"
-  type        = string
-  default     = null
-}


### PR DESCRIPTION
### Enable override of the default appname and subsystem

Default appname = the name of the firehose delivery stream


**** **removed subsytem override** option for now since this label doesnt really exist, and its default is not clear. 
Also, we need to take into consideration all of the cases that we offer here, for example only firehose, so what will be the default subsytem here ? 