### PR TITLE
FIX: aws provider config and update example

### DIFF
--- a/examples/eventbridge/main.tf
+++ b/examples/eventbridge/main.tf
@@ -1,3 +1,23 @@
+terraform {
+  # Set the backend here
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.17.1"
+    }
+  }
+}
+
+provider "aws" {
+  default_tags {
+    tags = {
+      terraform-module         = "kinesis-firehose-to-coralogix"
+      terraform-module-version = "v0.0.1"
+      managed-by               = "coralogix-terraform"
+    }
+  }
+}
+
 module "eventbridge_coralogix" {
   source                         = "github.com/coralogix/terraform-coralogix-aws//modules/eventbridge"
   eventbridge_stream             = var.coralogix_eventbridge_stream_name

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -1,7 +1,12 @@
-
-provider "aws" {
-  region = data.aws_region.current_region.name
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.17.1"
+    }
+  }
 }
+
 locals {
   endpoint_url = {
     "us" = {


### PR DESCRIPTION
The `required_providers` config for aws provider is missing in the eventbridge module, 
and the "region" config under the aws provider is wrong , the region is imported already , its not the right place. 