### PR TITLE
Enable override cx-application-name and add more events sources

### DIFF
--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -17,6 +17,8 @@ module "eventbridge_coralogix" {
 ### Examples
 Examples can be found under the [examples directory](https://github.com/coralogix/terraform-coralogix-aws/blob/master/examples/eventbridge)
 
+## Override Coralogix applicationName
+The application name by default is the eventbridge delivery stream name, but it can be overriden by setting an environment variable called `application_name`.
 
 # Coralogix account region
 The coralogix region variable accepts one of the following regions:

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -25,12 +25,12 @@ locals {
       url = "https://aws-events.eu2.coralogix.com/aws/event"
     }
   }
-
     tags = {
     terraform-module         = "eventbridge-to-coralogix"
-    terraform-module-version = "v0.0.1"
+    terraform-module-version = "v0.0.2"
     managed-by               = "coralogix-terraform"
   }
+  application_name = var.application_name == null ? "coralogix-${var.eventbridge_stream}" : var.application_name
 }
 
 data "aws_caller_identity" "current_identity" {}
@@ -90,6 +90,12 @@ resource "aws_cloudwatch_event_connection" "event-connectiong" {
       key   = "x-amz-event-bridge-access-key"
       value =var.private_key
     }
+    invocation_http_parameters {
+      header {
+        key             = "cx-application-name"
+        value           = local.application_name
+        is_value_secret = false
+      }
   }
 }
 resource "aws_cloudwatch_event_api_destination" "api-connection" {

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -21,5 +21,11 @@ variable "coralogix_region" {
 variable "sources" {
   type = list
   description = "The services for which we will send events"
-  default =["aws.ec2","aws.s3","aws.health"]
+  default = ["aws.ec2","aws.autoscaling","aws.ecr","aws.s3","aws.cloudwatch","aws.events","aws.health","aws.rds"]
+}
+
+variable "application_name" {
+  description = "Coralogix application name"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION
* Added the option to override the `coralogix application name`
* Added some `events sources` to the default sources variable [ec2, autoscaling, ecr, s3, cloudwathc, events, health, rds]
