### PR TITLE
adding support for custom firehose endpoints

### DIFF
--- a/modules/firehose/README.md
+++ b/modules/firehose/README.md
@@ -79,6 +79,9 @@ The coralogix region variable accepts one of the following regions:
 | india     | `https://firehose-ingress.app.coralogix.in/firehose`            |
 | stockholm | `https://firehose-ingress.coralogix.eu2.coralogix.com/firehose` |
 
+### Custom endpoints
+It is possible to pass a custom firehose ingress endpoint with by using the `coralogix_firehose_custom_endpoint` variable.
+
 # Metrics Output Format
 Coralogix suppots both `JSON` format and `OpenTelemtry` format. 
 The default format configured here is `OpenTelemtry`. 

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -27,7 +27,7 @@ locals {
   }
   tags = merge(var.user_supplied_tags, {
     terraform-module         = "kinesis-firehose-to-coralogix"
-    terraform-module-version = "v0.0.9"
+    terraform-module-version = "v0.1.0"
     managed-by               = "coralogix-terraform"
   })
   application_name = var.application_name == null ? "coralogix-${var.firehose_stream}" : var.application_name
@@ -251,7 +251,7 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream" {
   }
 
   http_endpoint_configuration {
-    url                = local.endpoint_url[var.coralogix_region].url
+    url                = var.coralogix_firehose_custom_endpoint != null ? var.coralogix_firehose_custom_endpoint : local.endpoint_url[var.coralogix_region].url
     name               = "Coralogix"
     access_key         = var.privatekey
     buffering_size     = 6

--- a/modules/firehose/variables.tf
+++ b/modules/firehose/variables.tf
@@ -59,3 +59,9 @@ variable "cloudwatch_retention_days" {
   type        = number
   default     = 1
 }
+
+variable "coralogix_firehose_custom_endpoint" {
+  description = "Custom endpoint for Coralogix firehose integration endpoint (https://firehose-ingress.private.coralogix.net:8443/firehose)"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
adding support for Coralogix custom endpoint (to go beyond the AWS Regions) when defining AWS Kinesis Firehose integration for Cloudwatch Metrics