### PR TITLE
Change BufferIntervalInSeconds default value to 61 sec

### DIFF
--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -297,7 +297,7 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream" {
 
         parameters {
           parameter_name  = "BufferIntervalInSeconds"
-          parameter_value = "60"
+          parameter_value = "61"
         }
       }
     }


### PR DESCRIPTION
There is a diff show up each time you deploy the module, under aws_kinesis_firehose_delivery_stream { http_endpoint_configuration { processing_configuration { processors {:
+                   parameters {
+                       parameter_name  = "BufferIntervalInSeconds"
+                       parameter_value = "60"
                    }

Seems like a small annoying issue, the workaround is to set the parameter as non default - 61