### PR TITLE
update the readme.md - vpc-flow-logs examples fix [CDS-313]

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ module "vpc_flow_logs" {
   layer_arn          = "<your layer arn>"
   application_name   = "vpc-flow-logs"
   subsystem_name     = "logs"
-  log_groups         = ["test-log-group"]
+  s3_bucket_name     = "test-bucket-name"
 }
 ```
 now execute:


### PR DESCRIPTION
 need to use s3_bucket_name instead of log_groups