### PR TITLE
Update permissions for transformation Lambda

### DIFF
--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -193,13 +193,18 @@ resource "aws_iam_role_policy" "lambda_iam_policy" {
       {
           "Action": [
               "tag:GetResources",
-              "ec2:DescribeTransitGateway*",
-              "ec2:DescribeTags",
-              "ec2:DescribeRegions",
-              "ec2:DescribeInstances",
-              "dms:DescribeReplicationTasks",
+              "cloudwatch:GetMetricData",
+              "cloudwatch:GetMetricStatistics",
+              "cloudwatch:ListMetrics",
+              "apigateway:GET",
+              "aps:ListWorkspaces",
+              "autoscaling:DescribeAutoScalingGroups",
               "dms:DescribeReplicationInstances",
-              "apigateway:GET"
+              "dms:DescribeReplicationTasks",
+              "ec2:DescribeTransitGatewayAttachments",
+              "ec2:DescribeSpotFleetRequests",
+              "storagegateway:ListGateways",
+              "storagegateway:ListTagsForResource"
           ],
           "Effect": "Allow",
           "Resource": "*",


### PR DESCRIPTION
In latest version of the transformation Lambda, we're covering more namespaces / AWS service (such as auto-scaling groups). To reflect this and to make sure the Lambda works correctly, we need to expand the permissions.

This is coming from upstream changes, the permissions can be compared here: https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/README.md#authentication