### PR TITLE
Update version for cycjimmy / semantic-release-action to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 19.0.2
           extra_plugins: |


### PR DESCRIPTION
Update the version in order to fix a bug in v2 when running the action - SyntaxError: Unexpected token '.'