### PR TITLE
integrationType keeps showing for metrics, default value incorrect

### DIFF
--- a/modules/firehose/variables.tf
+++ b/modules/firehose/variables.tf
@@ -49,7 +49,7 @@ variable "output_format" {
 variable "integration_type_metrics" {
   description = "The integration type of the firehose delivery stream: 'CloudWatch_Metrics_JSON' or 'CloudWatch_Metrics_OpenTelemetry070'"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "application_name" {


### PR DESCRIPTION
In case that you add a new module, make sure that you add a test file for that module.
The test file will need to have the basic template to run this module with all of the necessary resource.

In case that you added a new variable to module, and this variable is requierd for the module to run, make sure that you add this variable to the test folder to your module with the right value.