### PR TITLE
Add support to use private link with cloudwatch-log integration

### DIFF
--- a/examples/cloudwatch-logs/variables.tf
+++ b/examples/cloudwatch-logs/variables.tf
@@ -95,3 +95,15 @@ variable "layer_arn" {
   type        = string
   default     = ""
 }
+
+variable "subnet_ids" {
+  description = "The subnet id with the private link"
+  type        = list(string)
+  default     = [""]
+}
+
+variable "security_group_ids" {
+  description = "The security group id for assigned to the subnet_ids"
+  type        = list(string)
+  default     = [""]
+}

--- a/modules/cloudwatch-logs/CHANGELOG.md
+++ b/modules/cloudwatch-logs/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## cloudwatch-logs
 
-### version / full date
-* [Update/Bug fix] massage describe the changes
+### 0.0.1 / 3.8.2023
+* [Update] Add support to use a private link with coralogix - add subnet_id and security_group_id variable to connect the lambda to vpc.

--- a/modules/cloudwatch-logs/README.md
+++ b/modules/cloudwatch-logs/README.md
@@ -38,6 +38,8 @@ Manage the application which retrieves `CloudWatch` logs and sends them to your 
 | <a name="input_buffer_charset"></a> [buffer\_charset](#input\_buffer\_charset) | The charset to use for buffer decoding, possible options are [`utf8`, `ascii`] | `string` | `utf8` | no |
 | <a name="input_sampling_rate"></a> [sampling\_rate](#input\_sampling\_rate) | Send messages with specific rate | `number` | `1` | no |
 | <a name="input_log_groups"></a> [log\_groups](#input\_log\_groups) | The names of the CloudWatch log groups to watch | `list(string)` | n/a | yes |
+| <a name="input_subnet_ids"></a> [vpc\_subnet\_ids](#input\_subnet\_ids) | The ID of the subnet with the private_link that the lambda will be created in | `list(string)` | n/a | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | The ID of the security group of the subnet | `list(string)` | n/a | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Lambda function memory limit | `number` | `1024` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Lambda function timeout limit | `number` | `300` | no |
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | Lambda function architecture | `string` | `x86_64` | no |

--- a/modules/cloudwatch-logs/main.tf
+++ b/modules/cloudwatch-logs/main.tf
@@ -31,6 +31,9 @@ module "lambda" {
   timeout                = var.timeout
   create_package         = false
   destination_on_failure = aws_sns_topic.this.arn
+  vpc_subnet_ids         = var.subnet_ids
+  vpc_security_group_ids = var.security_group_ids
+  attach_network_policy  = true
   environment_variables = {
     CORALOGIX_URL   = var.custom_url == "" ? lookup(module.locals.coralogix_regions, var.coralogix_region, "Europe") : var.custom_url
     private_key     = var.private_key
@@ -75,6 +78,9 @@ module "lambdaSSM" {
   timeout                = var.timeout
   create_package         = false
   destination_on_failure = aws_sns_topic.this.arn
+  vpc_subnet_ids         = var.subnet_ids
+  vpc_security_group_ids = var.security_group_ids
+  attach_network_policy  = true
   environment_variables = {
     CORALOGIX_URL           = var.custom_url == "" ? lookup(module.locals.coralogix_regions, var.coralogix_region, "Europe") : var.custom_url
     AWS_LAMBDA_EXEC_WRAPPER = "/opt/wrapper.sh"

--- a/modules/cloudwatch-logs/variables.tf
+++ b/modules/cloudwatch-logs/variables.tf
@@ -95,3 +95,15 @@ variable "layer_arn" {
   type        = string
   default     = ""
 }
+
+variable "subnet_ids" {
+  description = "The subnet id with the private link"
+  type        = list(string)
+  default     = [""]
+}
+
+variable "security_group_ids" {
+  description = "The security group id for assigned to the subnet_ids"
+  type        = list(string)
+  default     = [""]
+}


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Create subnet_ids and security_group_ids variables to support private link
<!-- (provide issue number, if applicable; otherwise remove) -->

# How Has This Been Tested?

ran the integration with the changes and saw that logs arrive to coralogix.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)