### PR TITLE
Fix firehose policy management

### DIFF
--- a/modules/firehose/CHANGELOG.md
+++ b/modules/firehose/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## firehose
 
 ### version / full date
-* [Update/17-Aug-2023] fix duplicate IAM issue
+* [Update/5-Sep-2023] fix firehose policy management

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -79,13 +79,13 @@ resource "aws_s3_bucket_public_access_block" "firehose_bucket_bucket_access" {
 }
 
 resource "aws_iam_role" "firehose_to_coralogix" {
-  tags               = local.tags
-  name               = "${var.firehose_stream}-firehose"
+  tags = local.tags
+  name = "${var.firehose_stream}-firehose"
   assume_role_policy = jsonencode({
-    "Version"   = "2012-10-17",
+    "Version" = "2012-10-17",
     "Statement" = [
       {
-        "Action"    = "sts:AssumeRole",
+        "Action" = "sts:AssumeRole",
         "Principal" = {
           "Service" = "firehose.amazonaws.com"
         },
@@ -94,9 +94,9 @@ resource "aws_iam_role" "firehose_to_coralogix" {
     ]
   })
   inline_policy {
-    name   = "${var.firehose_stream}-firehose"
+    name = "${var.firehose_stream}-firehose"
     policy = jsonencode({
-      "Version"   = "2012-10-17",
+      "Version" = "2012-10-17",
       "Statement" = [
         {
           "Effect" = "Allow",
@@ -149,9 +149,7 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_logs" {
   count       = var.logs_enable == true ? 1 : 0
 
   dynamic "kinesis_source_configuration" {
-    for_each = var.source_type_logs == "KinesisStreamAsSource" && var.kinesis_stream_arn != null ? [
-      1
-    ] : []
+    for_each = var.source_type_logs == "KinesisStreamAsSource" && var.kinesis_stream_arn != null ? [1] : []
     content {
       kinesis_stream_arn = var.kinesis_stream_arn
       role_arn           = aws_iam_role.firehose_to_coralogix.arn

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -242,7 +242,7 @@ resource "aws_iam_role_policy_attachment" "additional_policy_attachment_2" {
 
 resource "aws_iam_policy" "firehose_to_coralogix_metric_policy" {
   count  = var.metric_enable == true ? 1 : 0
-  name   = "Coralogix-firehose_metric_policy"
+  name   = "${var.firehose_stream}-metrics-policy"
   tags   = local.tags
   policy = <<EOF
 {


### PR DESCRIPTION
# Description

There is an issue in terraform where using `aws_iam_role_policy` and `inline_policy` in the role itself causes an endless update. Deploying once will add the policy, deploying again will remove it.

This occurred with the following module setup(modified slightly):
```
module "cloudwatch_firehose_coralogix" {
  source             = "github.com/coralogix/terraform-coralogix-aws//modules/firehose"
  firehose_stream    = "coralogix-metrics"
  private_key        = data.aws_ssm_parameter.coralogix_api_key.value
  coralogix_region   = "us2"
  user_supplied_tags = module.label.user_supplied_labels
}
```

This fix will now allow each deploy from terraform to be unmodified.

Also fixing an issue with `tags_all`, the tags were not applied with the empty string from `custom_endpoint` when no custom domain was passed. For the time being, I put `_default_` as the value.

# How Has This Been Tested?

1. Deploy the changes using Terraform.
2. Deployed Terraform again and ensured there were no changes.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)