### PR TITLE
copy from PR 80, from https://github.com/badcure

### DIFF
--- a/modules/firehose/CHANGELOG.md
+++ b/modules/firehose/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## firehose
 
 ### version / full date
-* [Update/17-Aug-2023] fix duplicate IAM issue
+* [Update/5-Sep-2023] fix firehose policy management

--- a/modules/firehose/CHANGELOG.md
+++ b/modules/firehose/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## firehose
 
 ### version / full date
+* [Update/17-Aug-2023] fix duplicate IAM issue
 * [Update/5-Sep-2023] fix firehose policy management

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -32,7 +32,7 @@ locals {
     terraform-module         = "kinesis-firehose-to-coralogix"
     terraform-module-version = "v0.1.0"
     managed-by               = "coralogix-terraform"
-    custom_endpoint          = var.coralogix_firehose_custom_endpoint != null ? var.coralogix_firehose_custom_endpoint : ""
+    custom_endpoint          = var.coralogix_firehose_custom_endpoint != null ? var.coralogix_firehose_custom_endpoint : "_default_"
   })
 
   # default namings
@@ -239,10 +239,10 @@ resource "aws_iam_role_policy_attachment" "additional_policy_attachment_2" {
 # Firehose Metrics Stream
 ################################################################################
 
-resource "aws_iam_role_policy" "firehose_to_coralogix_metric_policy" {
+resource "aws_iam_policy" "firehose_to_coralogix_metric_policy" {
   count  = var.metric_enable == true ? 1 : 0
-  name   = "${var.firehose_stream}-metrics-addon"
-  role   = aws_iam_role.firehose_to_coralogix.id
+  name   = "${var.firehose_stream}-metrics-policy"
+  tags   = local.tags
   policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -311,6 +311,12 @@ resource "aws_iam_role_policy" "firehose_to_coralogix_metric_policy" {
     ]
 }
 EOF
+}
+
+resource "aws_iam_role_policy_attachment" "firehose_to_coralogix_metric_policy" {
+  count      = var.metric_enable == true ? 1 : 0
+  policy_arn = aws_iam_policy.firehose_to_coralogix_metric_policy[count.index].arn
+  role       = aws_iam_role.firehose_to_coralogix.name
 }
 
 data "aws_iam_policy_document" "lambda_assume_role" {


### PR DESCRIPTION
# Description

Created by https://github.com/badcure, copied over code as tests not passing (creds not carried over by fork)

There is an issue in terraform where using aws_iam_role_policy and inline_policy in the role itself causes an endless update. Deploying once will add the policy, deploying again will remove it.

This occurred with the following module setup(modified slightly):
```
module "cloudwatch_firehose_coralogix" {
  source             = "github.com/coralogix/terraform-coralogix-aws//modules/firehose"
  firehose_stream    = "coralogix-metrics"
  private_key        = data.aws_ssm_parameter.coralogix_api_key.value
  coralogix_region   = "us2"
  user_supplied_tags = module.label.user_supplied_labels
}
```
This fix will now allow each deploy from terraform to be unmodified.

Also fixing an issue with tags_all, the tags were not applied with the empty string from custom_endpoint when no custom domain was passed. For the time being, I put _default_ as the value.

# How Has This Been Tested?

* Deploy the changes using Terraform.
* Deployed Terraform again and ensured there were no changes.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)