### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ $ terraform apply
 - [cloudwatch-logs](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/cloudwatch-logs) - Send logs from `CloudWatch`.
 - [s3](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/s3) - Send logs from `S3` bucket.
 - [eventbridge](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/eventbridge) - Send logs from `eventbrdge`.
-- [firehose](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose) -  Send metrics stream and logs with `firehose`.
+- [firehose-logs](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose-logs) -  Send logs streams with `firehose`.
+- [firehose-metrics](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose-metrics) -  Send metric streams with `firehose`.
 - [kinesis](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/kinesis) - Send logs from `kinesis data stream` with lambda.
 - [resource-metadata](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/resource-metadata) - Send metadata from your AWS account to coralogix.
 

--- a/modules/firehose/CHANGELOG.md
+++ b/modules/firehose/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## firehose
 
-### version / full date
-* [Update/17-Aug-2023] fix duplicate IAM issue
-* [Update/5-Sep-2023] fix firehose policy management
-* [Update/5-Sep-2023] fix readme links for firehose logs and metric examples
+### 0.0.1 / 17.8.23
+* [Update] fix duplicate IAM issue
+
+### 0.0.1 / 5.9.23
+* [Update] fix firehose policy management
+* [Update] fix readme links for firehose logs and metric examples

--- a/modules/firehose/CHANGELOG.md
+++ b/modules/firehose/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### version / full date
 * [Update/17-Aug-2023] fix duplicate IAM issue
 * [Update/5-Sep-2023] fix firehose policy management
+* [Update/5-Sep-2023] fix readme links for firehose logs and metric examples


### PR DESCRIPTION
# Description

README in https://registry.terraform.io/modules/coralogix/aws/coralogix/latest#integrations are broken due to example change

# How Has This Been Tested?

Fixed links, links are working

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)