### PR TITLE
remove IAM role for EventBridge name default[CDS-605]

### DIFF
--- a/modules/resource-metadata/CHANGELOG.md
+++ b/modules/resource-metadata/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata
 
+### 0.0.3 / 6.9.2023
+* [Bug fix] Remove the IAM role named Default - there is no need for this role and it can cause a conflict.
+
 ### 0.0.2 / 16.8.2023
 * [Update] Add an option to use an existing secret instead of creating a new one with SSM, and remove ssm_enabled variable.
 

--- a/modules/resource-metadata/main.tf
+++ b/modules/resource-metadata/main.tf
@@ -21,7 +21,7 @@ module "eventbridge" {
   source = "terraform-aws-modules/eventbridge/aws"
 
   create_bus = false
-
+  create_role = false
   rules = {
     crons = {
       description         = "Trigger for a Lambda"


### PR DESCRIPTION
# Description
Add create_role = false so that a role named default will not be created, i checked and there is not need for him, and it could cause a conflict for customers that have a role with this name.
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?
Ran the integration without the role and i saw that i am still getting metadata to my coralogix account.
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)