### PR TITLE
Migrate Lambda transformation runtime

### DIFF
--- a/modules/firehose/CHANGELOG.md
+++ b/modules/firehose/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## firehose
 
+### 0.0.1 / 25 Oct 2023
+* [Update] Migrate transformation Lambda runtime
+
 ### 0.0.1 / 17.8.23
 * [Update] fix duplicate IAM issue
 

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -404,6 +404,7 @@ resource "aws_lambda_function" "lambda_processor" {
   runtime       = "provided.al2"
   timeout       = "60"
   memory_size   = 512
+  architectures = ["arm64"]
   tags          = local.tags
 
   environment {

--- a/modules/firehose/main.tf
+++ b/modules/firehose/main.tf
@@ -397,11 +397,11 @@ resource "aws_cloudwatch_log_group" "loggroup" {
 resource "aws_lambda_function" "lambda_processor" {
   count         = var.metric_enable && var.lambda_processor_enable ? 1 : 0
   s3_bucket     = "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.name}"
-  s3_key        = "function.zip"
+  s3_key        = "bootstrap.zip"
   function_name = local.lambda_processor_name
   role          = aws_iam_role.lambda_iam_role[count.index].arn
-  handler       = "function"
-  runtime       = "go1.x"
+  handler       = "bootstrap"
+  runtime       = "provided.al2"
   timeout       = "60"
   memory_size   = 512
   tags          = local.tags


### PR DESCRIPTION
# Description

Part of https://coralogix.atlassian.net/browse/ES-123

Reflects the changes needed for migrating the runtime (for details see https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/).

This also has been reflected already in the transformation Lambda, see related change: https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/pull/32

# How Has This Been Tested?
N/A

# Checklist:
- [X] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)