### PR TITLE
Add retention time to cw loggroup

### DIFF
--- a/examples/s3/s3.tf
+++ b/examples/s3/s3.tf
@@ -4,10 +4,11 @@ provider "aws" {
 module "coralogix-shipper" {
   source = "coralogix/aws/coralogix//modules/s3"
 
-  coralogix_region = "Europe"
-  private_key      = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
-  application_name = "s3"
-  subsystem_name   = "logs"
-  s3_bucket_name   = "test-bucket-name"
-  integration_type = "s3"
+  coralogix_region                  = "Europe"
+  private_key                       = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
+  application_name                  = "s3"
+  subsystem_name                    = "logs"
+  s3_bucket_name                    = "test-bucket-name"
+  integration_type                  = "s3"
+  cloudwatch_logs_retention_in_days = 7   # optional
 }

--- a/examples/s3/s3.tf
+++ b/examples/s3/s3.tf
@@ -10,5 +10,4 @@ module "coralogix-shipper" {
   subsystem_name                    = "logs"
   s3_bucket_name                    = "test-bucket-name"
   integration_type                  = "s3"
-  cloudwatch_logs_retention_in_days = 7   # optional
 }

--- a/examples/s3/s3.tf
+++ b/examples/s3/s3.tf
@@ -4,10 +4,10 @@ provider "aws" {
 module "coralogix-shipper" {
   source = "coralogix/aws/coralogix//modules/s3"
 
-  coralogix_region                  = "Europe"
-  private_key                       = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
-  application_name                  = "s3"
-  subsystem_name                    = "logs"
-  s3_bucket_name                    = "test-bucket-name"
-  integration_type                  = "s3"
+  coralogix_region = "Europe"
+  private_key      = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
+  application_name = "s3"
+  subsystem_name   = "logs"
+  s3_bucket_name   = "test-bucket-name"
+  integration_type = "s3"
 }

--- a/examples/s3/variables.tf
+++ b/examples/s3/variables.tf
@@ -151,3 +151,9 @@ variable "create_secret" {
   type        = string
   default     = "True"
 }
+
+variable "cloudwatch_logs_retention_in_days" {
+  description = "Retention time of the Cloudwatch log group in which the logs of the lambda function are written to"
+  type        = number
+  default     = null
+}

--- a/modules/s3/CHANGELOG.md
+++ b/modules/s3/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## S3
 
+### 0.0.5 / 15.11.2023
+* [Update] Add an option to specify the retention time of the CloudWatch log group that is created by the lambda
+
 ### 0.0.4 / 4.10.2023
 * [bug_fix] Add secret_manager_enabled variable to allow the use of lambda-SecretLayer in the same run with this module 
 

--- a/modules/s3/README.md
+++ b/modules/s3/README.md
@@ -53,6 +53,7 @@ Manage the application which retrieves logs from `S3` bucket and sends them to y
 | <a name="input_architecture"></a> [architecture](#input\_architecture) | Lambda function architecture | `string` | `x86_64` | no |
 | <a name="input_notification_email"></a> [notification_email](#input\_notification\_email) | Failure notification email address | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_cloudwatch_logs_retention_in_days"></a> [cloudwatch\_logs\_retention\_in\_days](#input\_cloudwatch\_logs\_retention\_in\_days) | Retention time of the Cloudwatch log group in which the logs of the lambda function are written to | `number` | `null` | no |
 
 ### Note:
 You should use the `custom_s3_bucket` variable only when you need to deploy the integration in aws region that coralogix doesn't have a public bucket in (i.e for GovCloud), when using this variable you will need to create a bucket in the region that you want to run the integration in, and pass this bucket name as `custom_s3_bucket`. The module will download the integration file to your local workspace, and then upload these files to the `custom_s3_bucket`, and remove the file from your local workspace.

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -145,6 +145,7 @@ module "lambdaSM" {
   role_path                               = "/coralogix/"
   role_name                               = "${module.locals.function_name}-Role"
   role_description                        = "Role for ${module.locals.function_name} Lambda Function."
+  cloudwatch_logs_retention_in_days       = var.cloudwatch_logs_retention_in_days
   create_current_version_allowed_triggers = false
   create_async_event_config               = true
   attach_async_event_policy               = true

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -88,6 +88,7 @@ module "lambda" {
   role_path                               = "/coralogix/"
   role_name                               = "${module.locals.function_name}-Role"
   role_description                        = "Role for ${module.locals.function_name} Lambda Function."
+  cloudwatch_logs_retention_in_days       = var.cloudwatch_logs_retention_in_days
   create_current_version_allowed_triggers = false
   create_async_event_config               = true
   attach_async_event_policy               = true

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -144,3 +144,9 @@ variable "create_secret" {
   type        = string
   default     = "True"
 }
+
+variable "cloudwatch_logs_retention_in_days" {
+  description = "Retention time of the Cloudwatch log group in which the logs of the lambda function are written to"
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
# Description

This pull request adds the option to specify a retention time of the CloudWatch log group that is created by the lambda, which does the shipping of the S3 log data to Coralogix. In particular, for some log types (like CloudTrail or VPC flow logs) the lambda creates much output, thereby creating large CloudWatch log groups. For most use cases, these logs in CloudWatch are not necessary and a short retention time is sufficient.

# How Has This Been Tested?

The module was instantiated with the new variable set to 7 (i.e., one week retention)  and checked that the resulting CloudWatch Log Group has the corresponding retention time:

module "coralogix-shipper-s3" {
  source = "<local_path>/terraform-coralogix-aws/modules/s3"

  coralogix_region = var.coralogix_region
  custom_url       = var.coralogix_custom_url
  private_key      = var.coralogix_private_key
  application_name = var.coralogix_application_name
  subsystem_name   = var.coralogix_subsystem_name
  s3_bucket_name   = var.bucket_name
  integration_type = "s3"
  s3_key_prefix    = local.s3_key_prefix

  cloudwatch_logs_retention_in_days = 7

  tags = var.custom_tags
}

# Checklist:
- [X ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)