### PR TITLE
Readme add section for ecs-ec2 module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# AWS Coralogix Terraform module
+# AWS Coralogix Terraform modules
 
 ## Examples
 
-# s3:
+### s3:
 
 ```hcl
 provider "aws" {
@@ -26,7 +26,7 @@ $ terraform plan
 $ terraform apply
 ```
 
-# cloudwatch-logs:
+### cloudwatch-logs:
 
 To run this example you need to save this code in Terraform file, and change the values according to our settings.
 
@@ -53,8 +53,37 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
+### ECS-EC2
 
-# kinesis:
+Provision an ECS Service that run the OTEL Collector Agent as a Daemon container on each EC2 container instance.
+For parameter details, see [ECS-EC2 module README](./modules/ecs-ec2/README.md)
+
+```hcl
+module "ecs-ec2" {
+  source                   = "../../modules/ecs-ec2"
+  ecs_cluster_name         = "ecs-cluster-name"
+  image_version            = "latest"
+  memory                   = numeric MiB
+  coralogix_region         = ["Europe"|"Europe2"|"India"|"Singapore"|"US"|"US2"]
+  custom_domain            = "[optional] custom Coralogix domain"
+  default_application_name = "Coralogix Application Name"
+  default_subsystem_name   = "Coralogix Subsystem Name"
+  api_key                  = var.api_key
+  otel_config_file         = "[optional] file path to custom OTEL collector config file"
+  metrics                  = [true|false]
+}
+```
+
+now execute:
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Run `terraform destroy` when you don't need these resources.
+
+### kinesis:
 
 ```hcl
 provider "aws" {
@@ -79,7 +108,7 @@ $ terraform apply
 
 Run `terraform destroy` when you don't need these resources.
 
-# firehose:
+### firehose:
 
 ```hcl
 provider "aws" {
@@ -110,7 +139,7 @@ $ terraform plan
 $ terraform apply
 ```
 
-# resource-metadata:
+### resource-metadata:
 
 ```hcl
 provider "aws" {
@@ -136,6 +165,7 @@ $ terraform apply
 
 - [cloudwatch-logs](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/cloudwatch-logs) - Send logs from `CloudWatch`.
 - [s3](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/s3) - Send logs from `S3` bucket.
+- [ecs-ec2](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/ecs-ec2) - Send logs, metrics, traces from OTEL Collector on ECS EC2 container instances.
 - [eventbridge](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/eventbridge) - Send logs from `eventbrdge`.
 - [firehose-logs](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose-logs) -  Send logs streams with `firehose`.
 - [firehose-metrics](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose-metrics) -  Send metric streams with `firehose`.

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -13,7 +13,7 @@ module "ecs-ec2" {
   image_version            = "latest"
   memory                   = numeric MiB
   coralogix_region         = ["Europe"|"Europe2"|"India"|"Singapore"|"US"|"US2"]
-  custom_domain            = "your custom Coralogix domain"
+  custom_domain            = "[optional] custom Coralogix domain"
   default_application_name = "Coralogix Application Name"
   default_subsystem_name   = "Coralogix Subsystem Name"
   api_key                  = var.api_key


### PR DESCRIPTION
# Description

Minor: add readme doc section for ecs-ec2 terraform module [PR 101](https://github.com/coralogix/terraform-coralogix-aws/pull/101)
Feature request: [CDS-762 ](https://coralogix.atlassian.net/browse/CDS-762) Create OTEL ecs-ec2 Terraform.

# How Has This Been Tested?

Readme preview

# Checklist:
- [ N.A.] I have updated the relevant example in the examples directory for the module.
- [ N.A.] I have updated the relevant test file for the module.
- [ ✅ ] This change does not affect module (e.g. it's readme file change)