### PR TITLE
[Feature] Allow Bucket Destruction via Code

### DIFF
--- a/modules/provisioning/s3-archive/main.tf
+++ b/modules/provisioning/s3-archive/main.tf
@@ -17,7 +17,7 @@ resource "aws_s3_bucket" "logs_bucket_name" {
   count  = local.logs_validations ? 1 : 0
   bucket = var.logs_bucket_name
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = var.bypass_bucket_lifecycle_prevent_destroy
   }
 }
 
@@ -25,7 +25,7 @@ resource "aws_s3_bucket" "metrics_bucket_name" {
   count  = local.metrics_validations ? 1 : 0
   bucket = var.metrics_bucket_name
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = var.bypass_bucket_lifecycle_prevent_destroy
   }
 }
 

--- a/modules/provisioning/s3-archive/variables.tf
+++ b/modules/provisioning/s3-archive/variables.tf
@@ -14,6 +14,12 @@ variable "bypass_valid_region" {
   default     = ""
 }
 
+variable "bypass_bucket_lifecycle_prevent_destroy" {
+  type        = bool
+  description = "Use this to bypass the bucket lifecycle so that you can (if needed) use terraform destroy to turn down infrastructure"
+  default     = true
+}
+
 variable "custom_coralogix_arn" {
   type        = string
   description = "In case that you want to use a custom coralogix arn enter the aws account id that you want to use"


### PR DESCRIPTION
# Description

User will end up with the following error message when attempting to destroy presently...

```
│ Error: Instance cannot be destroyed
│
│   on .terraform/modules/coralogix_s3/modules/provisioning/s3-archive/main.tf line 16:
│   16: resource "aws_s3_bucket" "logs_bucket_name" {
│
│ Resource module.coralogix_s3.aws_s3_bucket.logs_bucket_name[0] has lifecycle.prevent_destroy set, but the plan calls for this resource to be destroyed. To avoid this error and continue with the plan, either
│ disable lifecycle.prevent_destroy or reduce the scope of the plan using the -target flag.
```

# How Has This Been Tested?

Setting lifecycle to false and running code manually after downloading the module w/ `terraform init` and then running a `terraform destroy`.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)