### PR TITLE
Reduce Secret Manager IAM permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.75
+### 💡 Enhancements 💡
+#### **coralogix-aws-shipper**
+- Reduce Secret Manage IAM permissions
+
 ## v1.0.74
 ### 🧰 Bug fixes 🧰
 #### ֿ**coralogix-aws-shipper**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v1.0.75
-### 💡 Enhancements 💡
+### 🧰 Bug fixes 🧰
 #### **coralogix-aws-shipper**
 - Reduce Secret Manage IAM permissions
 


### PR DESCRIPTION
# Description
Reduce Secret Manager IAM permissions so that the lambda will have permissions to the secret that it create or to the secret that stores the api_key of the user otherwise it will not have permission to the secret manager.
Also made some semantic changes - changed the secret_access_policy and destination_on_failure_policy to be as local variables.
<!-- (provide issue number, if applicable; otherwise remove) --> 

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)