### PR TITLE
Fix ECS deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.81
+### 🧰 Bug fixes 🧰
+#### **ecs-ec2**  
+- Missing resource instance key
+
 ## v1.0.80
 ### 🚀 New components 🚀
 #### **coralogix-aws-shipper**

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -122,7 +122,7 @@ resource "aws_ecs_service" "coralogix_otel_agent" {
   name                               = "${local.name}-${random_string.id.result}"
   cluster                            = var.ecs_cluster_name
   launch_type                        = "EC2"
-  task_definition                    = var.task_definition_arn == null ? aws_ecs_task_definition.coralogix_otel_agent.arn : var.task_definition_arn
+  task_definition                    = var.task_definition_arn == null ? aws_ecs_task_definition.coralogix_otel_agent[0].arn : var.task_definition_arn
   scheduling_strategy                = "DAEMON"
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0

--- a/modules/ecs-ec2/output.tf
+++ b/modules/ecs-ec2/output.tf
@@ -1,5 +1,5 @@
 output "coralogix_otel_agent_task_definition_arn" {
-  value       = var.task_definition_arn == null ? null : aws_ecs_task_definition.coralogix_otel_agent[0].arn
+  value       = one(aws_ecs_task_definition.coralogix_otel_agent[*].arn)
   description = "ARN of the ECS Task Definition for the OTEL Agent Daemon"
 }
 

--- a/modules/ecs-ec2/output.tf
+++ b/modules/ecs-ec2/output.tf
@@ -1,7 +1,8 @@
 output "coralogix_otel_agent_task_definition_arn" {
-  value       = aws_ecs_task_definition.coralogix_otel_agent.arn
+  value       = var.task_definition_arn == null ? null : aws_ecs_task_definition.coralogix_otel_agent[0].arn
   description = "ARN of the ECS Task Definition for the OTEL Agent Daemon"
 }
+
 output "coralogix_otel_agent_service_id" {
   value       = aws_ecs_service.coralogix_otel_agent.id
   description = "ID of the ECS Service for the OTEL Agent Daemon"


### PR DESCRIPTION
This PR fixes a bug introduced at PR #123.
The root cause is a conditional creation of the `aws_ecs_task_definition` using `count`, which causes the following errors:
```
╷
│ Error: Missing resource instance key
│ 
│   on .terraform/modules/ecs_log_shipper/modules/ecs-ec2/main.tf line 125, in resource "aws_ecs_service" "coralogix_otel_agent":
│  125:   task_definition                    = var.task_definition_arn == null ? aws_ecs_task_definition.coralogix_otel_agent.arn : var.task_definition_arn
│ 
│ Because aws_ecs_task_definition.coralogix_otel_agent has "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     aws_ecs_task_definition.coralogix_otel_agent[count.index]
╵
╷
│ Error: Missing resource instance key
│ 
│   on .terraform/modules/ecs_log_shipper/modules/ecs-ec2/output.tf line 2, in output "coralogix_otel_agent_task_definition_arn":
│    2:   value       = aws_ecs_task_definition.coralogix_otel_agent.arn
│ 
│ Because aws_ecs_task_definition.coralogix_otel_agent has "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     aws_ecs_task_definition.coralogix_otel_agent[count.index]
╵

```

# How Has This Been Tested?

Deployed in production from an upstream fork

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)