### PR TITLE
S3 archive update role for metrics bucket [CDS-982]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.82
+### 🧰 Bug fixes 🧰
+#### **s3-archive**  
+- Update the role for the metrics bucket
+
 ## v1.0.81
 ### 🧰 Bug fixes 🧰
 #### **ecs-ec2**  

--- a/modules/provisioning/s3-archive/main.tf
+++ b/modules/provisioning/s3-archive/main.tf
@@ -9,7 +9,8 @@ locals {
   metrics_validations    = local.is_metrics_bucket_name_empty && !local.is_same_bucket_name && (local.is_valid_region || var.bypass_valid_region != "")
   kms_logs_validation    = local.logs_validations && var.logs_kms_arn != "" && contains(split(":", var.logs_kms_arn), var.aws_region)
   kms_metrics_validation = local.metrics_validations && var.metrics_kms_arn != "" && contains(split(":", var.metrics_kms_arn), var.aws_region)
-  coralogix_arn          = var.custom_coralogix_arn != "" ? "arn:aws:iam::${var.custom_coralogix_arn}:role/coralogix-archive-${local.coralogix_role_region}" : var.bypass_valid_region != "" ? "arn:aws:iam::${var.coralogix_arn_mapping[""]}:role/coralogix-archive-${local.coralogix_role_region}" : "arn:aws:iam::${var.coralogix_arn_mapping[var.aws_region]}:role/coralogix-archive-${local.coralogix_role_region}"
+  coralogix_log_role_arn = var.custom_coralogix_arn != "" ? "arn:aws:iam::${var.custom_coralogix_arn}:role/coralogix-archive-${local.coralogix_role_region}" : var.bypass_valid_region != "" ? "arn:aws:iam::${var.coralogix_arn_mapping[""]}:role/coralogix-archive-${local.coralogix_role_region}" : "arn:aws:iam::${var.coralogix_arn_mapping[var.aws_region]}:role/coralogix-archive-${local.coralogix_role_region}"
+  coralogix_metrics_role_arn = var.custom_coralogix_arn != "" ? "arn:aws:iam::${var.custom_coralogix_arn}:root" : var.bypass_valid_region != "" ? "arn:aws:iam::${var.coralogix_arn_mapping[""]}:root" : "arn:aws:iam::${var.coralogix_arn_mapping[var.aws_region]}:root"
 }
 
 data "aws_region" "current" {}
@@ -39,7 +40,7 @@ resource "aws_s3_bucket_policy" "logs_bucket_policy" {
       {
         Effect = "Allow"
         Principal = {
-          AWS = local.coralogix_arn
+          AWS = local.coralogix_log_role_arn
         }
         Action = [
           "s3:GetObject",
@@ -78,7 +79,7 @@ resource "aws_s3_bucket_policy" "metrics_bucket_policy" {
       {
         Effect = "Allow"
         Principal = {
-          AWS = local.coralogix_arn
+          AWS = local.coralogix_metrics_role_arn
         }
         Action = [
           "s3:GetObject",


### PR DESCRIPTION
# Description
Update the role for the metrics bucket, the new role `arn:aws:iam::${aws_account_id}:role/coralogix-archive-${aws_role_region}` is working right now only for logs and not metrics
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)