### PR TITLE
[ecs-ec2] OTEL Agent mount path scope fix. Bugfix for region codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.88
+### 🧰 Bug fixes 🧰
+#### **ecs-ec2**
+- fixes ecs-ec2 bugs from v1.0.87
+
 ## v1.0.87
 ### 💡 Enhancements and Bug fixes 🧰
 #### **ecs-ec2**

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Coralogix provides the following integration:
 AWS Lambda function used to send logs from different AWS services like S3/Kinesis/CloudWatch/etc - [coralogix-aws-shipper](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/coralogix-aws-shipper)
 
 
-### ECS-EC2
-Provision an ECS Service that run the OTEL Collector Agent as a Daemon container on each EC2 container instance - [ECS-EC2](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/ecs-ec2)
+### ecs-ec2:
+The Coralogix OpenTelemetry Agent for ECS-EC2 Terraform module deploys the Coralogix Distribution for Open Telemetry ("CDOT") Collector Agent as a Daemon ECS service on each EC2 container instance - [ecs-ec2](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/ecs-ec2)
 
 ### firehose-logs:
 Firehose Logs module is designed to support AWS Firehose Logs integration with Coralogix - [firehose-logs](https://github.com/coralogix/terraform-coralogix-aws/tree/master/examples/firehose-logs)

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -1,4 +1,4 @@
-# ECS EC2 Open Telemetry Agent
+# Coralogix OpenTelemetry Agent for ECS-EC2. Terraform module.
 
 Terraform module to launch the Coralogix Distribution for Open Telemetry ("CDOT") into an existing AWS ECS Cluster, in the OTEL [Agent deployment](https://opentelemetry.io/docs/collector/deployment/agent/) pattern. The module is available on the [Terraform Registry](https://registry.terraform.io/modules/coralogix/aws/coralogix/latest/submodules/ecs-ec2).
 
@@ -22,11 +22,11 @@ Provision an ECS Service that run the OTEL Collector Agent as a Daemon container
 <!--For local dev, set local path to source, e.g. ```source  = "../../modules/ecs-ec2"```-->
 ```terraform
 module "ecs-ec2" {
-  source                   = "github.com/coralogix/terraform-coralogix-aws/modules/ecs-ec2"
+  source                   = "coralogix/aws/coralogix//modules/ecs-ec2"
   ecs_cluster_name         = "ecs-cluster-name"
   image_version            = "latest"
   memory                   = numeric MiB
-  coralogix_region         = ["Europe"|"Europe2"|"India"|"Singapore"|"US"|"US2"]
+  coralogix_region         = ["EU1"|"EU2"|"AP1"|"AP2"|"US1"|"US2"]
   custom_domain            = "[optional] custom Coralogix domain"
   default_application_name = "Coralogix Application Name"
   default_subsystem_name   = "Coralogix Subsystem Name"

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -1,3 +1,9 @@
+module "locals_variables" {
+  source = "coralogix/aws/coralogix//modules/locals_variables"
+  integration_type = null
+  random_string = "foo"
+}
+
 locals {
   name = "coralogix-otel-agent"
   tags = merge(
@@ -6,7 +12,8 @@ locals {
     },
     var.tags
   )
-  coralogix_region_domain_map = {
+  coralogix_region_domain_map = locals_variables.coralogix_regions
+  coralogix_region_domain_map_DEPRECATED = {
     # The following is the new set of region codes
     "EU1"       = "coralogix.com"
     "EU2"       = "eu2.coralogix.com"

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -1,9 +1,3 @@
-module "locals_variables" {
-  source = "coralogix/aws/coralogix//modules/locals_variables"
-  integration_type = null
-  random_string = "foo"
-}
-
 locals {
   name = "coralogix-otel-agent"
   tags = merge(
@@ -12,29 +6,18 @@ locals {
     },
     var.tags
   )
-  coralogix_region_domain_map = locals_variables.coralogix_regions
-  coralogix_region_domain_map_DEPRECATED = {
-    # The following is the new set of region codes
-    "EU1"       = "coralogix.com"
-    "EU2"       = "eu2.coralogix.com"
-    "AP1"       = "coralogix.in"
-    "AP2"       = "coralogixsg.com"
-    "US1"       = "coralogix.us"
-    "US2"       = "cx498.coralogix.com"
-    "custom"    = null
-    # The following pre-2024-02-xx legacy codes to be deprecated.
-    "Europe"    = "coralogix.com"
-    "Europe2"   = "eu2.coralogix.com"
-    "India"     = "coralogix.in"
-    "Singapore" = "coralogixsg.com"
-    "US"        = "coralogix.us"
-    "US2"       = "cx498.coralogix.com"
-  }
+  coralogix_region_domain_map = module.locals_variables.coralogix_domains
   coralogix_domain = coalesce(var.custom_domain, local.coralogix_region_domain_map[var.coralogix_region])
   otel_config_file = coalesce(var.otel_config_file,
     (var.metrics ? "${path.module}/otel_config_metrics.tftpl.yaml" : "${path.module}/otel_config.tftpl.yaml")
   )
   otel_config = templatefile(local.otel_config_file, {})
+}
+
+module "locals_variables" {
+  source = "../locals_variables" # "coralogix/aws/coralogix//modules/locals_variables"
+  integration_type = "ecs-ec2"
+  random_string    = random_string.this.result
 }
 
 resource "random_string" "id" {

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -16,14 +16,14 @@ locals {
     "US2"       = "cx498.coralogix.com"
     "custom"    = null
     # The following pre-2024-02-xx legacy codes to be deprecated.
-    "europe"    = "coralogix.com"
-    "europe2"   = "eu2.coralogix.com"
-    "india"     = "coralogix.in"
-    "singapore" = "coralogixsg.com"
-    "us"        = "coralogix.us"
-    "us2"       = "cx498.coralogix.com"
+    "Europe"    = "coralogix.com"
+    "Europe2"   = "eu2.coralogix.com"
+    "India"     = "coralogix.in"
+    "Singapore" = "coralogixsg.com"
+    "US"        = "coralogix.us"
+    "US2"       = "cx498.coralogix.com"
   }
-  coralogix_domain = coalesce(var.custom_domain, local.coralogix_region_domain_map[lower(var.coralogix_region)])
+  coralogix_domain = coalesce(var.custom_domain, local.coralogix_region_domain_map[var.coralogix_region])
   otel_config_file = coalesce(var.otel_config_file,
     (var.metrics ? "${path.module}/otel_config_metrics.tftpl.yaml" : "${path.module}/otel_config.tftpl.yaml")
   )

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -17,7 +17,7 @@ locals {
 module "locals_variables" {
   source = "../locals_variables" # "coralogix/aws/coralogix//modules/locals_variables"
   integration_type = "ecs-ec2"
-  random_string    = random_string.this.result
+  random_string    = random_string.id.result
 }
 
 resource "random_string" "id" {

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "locals_variables" {
-  source = "../locals_variables" # "coralogix/aws/coralogix//modules/locals_variables"
+  source = "../locals_variables"
   integration_type = "ecs-ec2"
   random_string    = random_string.id.result
 }

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -21,11 +21,11 @@ variable "memory" {
 }
 
 variable "coralogix_region" {
-  description = "The region of the Coralogix endpoint domain: [Europe, Europe2, India, Singapore, US, US2, Custom]. If \"Custom\" then __custom_domain__ parameter must be specified."
+  description = "The region of the Coralogix endpoint domain: [EU1|EU2|AP1|AP2|US1|US2|custom]. If \"custom\" then __custom_domain__ parameter must be specified."
   type        = string
   validation {
-    condition     = can(regex(lower("^(europe|europe2|india|singapore|us|us2|custom|EU1|EU2|AP1|AP2|US1|US2)$"), lower(var.coralogix_region)))
-    error_message = "Must be one of [EU1|EU2|AP1|AP2|US1|US2]. Please note deprecation of the following legacy region codes: [Europe, Europe2, India, Singapore, US, US2, Custom]. May be removed as soon as 1-3 releases after current release (v1.0.87)."
+    condition     = can(regex("^(EU1|EU2|AP1|AP2|US1|US2|custom|Europe|Europe2|India|Singapore|US|US2)$", var.coralogix_region))
+    error_message = "Must be one of [EU1|EU2|AP1|AP2|US1|US2|custom]. Please note deprecation of previous legacy region codes."
   }
 }
 


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
* OTEL Agent daemon container mounts host filesystem read-only at `/` path, which is a security concern and data confidentiality risk. This change restricts the read-only mount to `/var/lib/docker/`.
* Bugfix for region codes validation bug error, which blocks stack creation.

Bug: ```terraform plan``` error.
```
Plan: 13 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid index
│ 
│   on ../../../terraform-coralogix-aws/modules/ecs-ec2/main.tf line 12, in locals:
│   12:   coralogix_domain = coalesce(var.custom_domain, local.coralogix_region_domain_map[var.coralogix_region])
│     ├────────────────
│     │ local.coralogix_region_domain_map is object with 6 attributes
│     │ var.coralogix_region is "US1"
│ 
│ The given key does not identify an element in this collection value.
```
<!-- (provide issue number, if applicable; otherwise remove) --> 
Fixes # [CDS-942](https://coralogix.atlassian.net/jira/servicedesk/projects/CDS/queues/custom/134/CDS-942)

# How Has This Been Tested?

Create TF that instantiates this module. An OTEL service is deployed successfully into an ECS cluster.
```bash
terraform init
terraform plan
terraform apply -auto-approve
terraform destroy -auto-approve
```


# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)

[CDS-942]: https://coralogix.atlassian.net/browse/CDS-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ