### PR TITLE
ECS-EC2 module, set default otel log level to warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.0.89
+### 💡 Enhancements 💡
+- ECS-EC2 module, set log level to warn by default for otel configurations
 
 ## v1.0.88
 ### 🧰 Bug fixes 🧰

--- a/modules/ecs-ec2/otel_config.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config.tftpl.yaml
@@ -78,6 +78,8 @@ service:
   extensions:
     - health_check
   telemetry:
+    logs:
+      level: warn
     metrics:
       address: 0.0.0.0:8888
       level: detailed

--- a/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
@@ -77,6 +77,8 @@ service:
   extensions:
     - health_check
   telemetry:
+    logs:
+      level: warn
     metrics:
       address: 0.0.0.0:8888
       level: detailed


### PR DESCRIPTION
- set log levels to warn by default
- changelog

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)