### PR TITLE
cds-1099 - add recombine configuration to otel ecs-ec2 configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## v1.0.92
+### 💡 Enhancements 💡
+- [cds-1099] add recombine operator to default configuration for opentelemetry ecs-ec2 integration
 
 ## v1.0.91
 ### 🚀 New components 🚀

--- a/modules/ecs-ec2/otel_config.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config.tftpl.yaml
@@ -16,10 +16,26 @@ receivers:
   filelog:
     start_at: end
     include:
-      - /hostfs/containers/*/*.log
+      - /hostfs/var/lib/docker/containers/*/*.log
     include_file_path: true
     # add log.file.path to resource attributes
     operators:
+      - type: json_parser
+        parse_from: body
+        parse_to: body
+        timestamp:
+          parse_from: body.time
+          layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+
+      - type: recombine
+        id: recombine
+        combine_field: body.log
+        source_identifier: attributes["log.file.path"]
+        is_last_entry: body.log endsWith "\n"
+        force_flush_period: 10s
+        on_error: drop
+        combine_with: ""
+
       - type: move
         from: attributes["log.file.path"]
         to: resource["log.file.path"]

--- a/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
@@ -16,10 +16,26 @@ receivers:
   filelog:
     start_at: end
     include:
-      - /hostfs/containers/*/*.log
+      - /hostfs/var/lib/docker/containers/*/*.log
     include_file_path: true
     # add log.file.path to resource attributes
     operators:
+      - type: json_parser
+        parse_from: body
+        parse_to: body
+        timestamp:
+          parse_from: body.time
+          layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+
+      - type: recombine
+        id: recombine
+        combine_field: body.log
+        source_identifier: attributes["log.file.path"]
+        is_last_entry: body.log endsWith "\n"
+        force_flush_period: 10s
+        on_error: drop
+        combine_with: ""
+
       - type: move
         from: attributes["log.file.path"]
         to: resource["log.file.path"]


### PR DESCRIPTION
- changelog
- add recombine operator to default configuration for opentelemetry ecs-ec2 integration

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)