### PR TITLE
Set Force Flush value to 0 in ecs-ec2 otel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## v1.0.93
+### 💡 Enhancements 
+- [cds-1099] set default force_flush_period parameter to 0 for ecs-ec2 otel filelog receiver💡
+
 ## v1.0.92
 ### 💡 Enhancements 💡
 - [cds-1099] add recombine operator to default configuration for opentelemetry ecs-ec2 integration

--- a/modules/ecs-ec2/otel_config.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config.tftpl.yaml
@@ -15,6 +15,7 @@ receivers:
   awsecscontainermetricsd:
   filelog:
     start_at: end
+    force_flush_period: 0
     include:
       - /hostfs/var/lib/docker/containers/*/*.log
     include_file_path: true

--- a/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
@@ -15,6 +15,7 @@ receivers:
   awsecscontainermetricsd:
   filelog:
     start_at: end
+    force_flush_period: 0
     include:
       - /hostfs/var/lib/docker/containers/*/*.log
     include_file_path: true


### PR DESCRIPTION
- set default force_flush_period parameter to 0 for ecs-ec2 otel filelog receiver
- changelog

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)