### PR TITLE
Fix permissions for ecr integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## v1.0.93
+#### **coralogix-aws-shipper**
+### 🧰 Bug fixes 🧰
+- Update permissions for EcrScan integration
+
 ## v1.0.92
 ### 💡 Enhancements 💡
 - [cds-1099] add recombine operator to default configuration for opentelemetry ecs-ec2 integration

--- a/modules/coralogix-aws-shipper/main.tf
+++ b/modules/coralogix-aws-shipper/main.tf
@@ -98,7 +98,7 @@ module "lambda" {
       resources = ["${data.aws_s3_bucket.this[0].arn}/*", data.aws_s3_bucket.this[0].arn]
     } : {
         effect = "Deny"
-        actions = ["ecr:DescribeImageScanFindings"]
+        actions = ["rds:DescribeAccountAttributes"]
         resources = ["*"]
     } 
     integrations_policy = var.s3_bucket_name != null && var.sqs_name == null ? {


### PR DESCRIPTION
# Description
The default permission for the lambda had deny ecr:DescribeImageScanFindings permission,  which cause the integration in case you use Ecr to fail 
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)