### PR TITLE
[CDS-1198] Default metrics type as WithAggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.97
+#### firehose-metrics
+### 💡 Enhancements 
+- [cds-1198] set default type parameter to CloudWatch_Metrics_OpenTelemetry070_WithAggregations
+
 ## v1.0.96
 #### **coralogix-aws-shipper**
 ### 🧰 Bug fixes 🧰

--- a/examples/firehose-metrics/variables.tf
+++ b/examples/firehose-metrics/variables.tf
@@ -18,7 +18,7 @@ variable "private_key" {
 variable "integration_type_metrics" {
   description = "The integration type of the firehose delivery stream: 'CloudWatch_Metrics_OpenTelemetry070' or 'CloudWatch_Metrics_OpenTelemetry070_WithAggregations'"
   type        = string
-  default     = "CloudWatch_Metrics_OpenTelemetry070"
+  default     = "CloudWatch_Metrics_OpenTelemetry070_WithAggregations"
 }
 
 variable "enable_cloudwatch_metricstream" {

--- a/modules/firehose-metrics/variables.tf
+++ b/modules/firehose-metrics/variables.tf
@@ -45,7 +45,7 @@ variable "custom_domain" {
 variable "integration_type_metrics" {
   description = "The integration type of the firehose delivery stream: 'CloudWatch_Metrics_OpenTelemetry070' or 'CloudWatch_Metrics_OpenTelemetry070_WithAggregations'"
   type        = string
-  default     = "CloudWatch_Metrics_OpenTelemetry070"
+  default     = "CloudWatch_Metrics_OpenTelemetry070_WithAggregations"
 }
 
 variable "output_format" {


### PR DESCRIPTION
Firehose default metrics type as WithAggregations

# Description

Firehose default metrics type CloudWatch_Metrics_OpenTelemetry070_WithAggregations

# How Has This Been Tested?

Locally, variable was an option before

# Checklist:
- [X] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)