### PR TITLE
Add NO_COLOR env var to coralogix-aws-shipper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.98
+#### **coralogix-aws-shipper**
+### 💡 Enhancements 
+- Set NO_COLOR environment variable to avoid ascii control characters in cloudwatch logs
+
 ## v1.0.97
 #### firehose-metrics
 ### 💡 Enhancements 

--- a/modules/coralogix-aws-shipper/main.tf
+++ b/modules/coralogix-aws-shipper/main.tf
@@ -59,6 +59,7 @@ module "lambda" {
     ADD_METADATA       = var.add_metadata
     CUSTOM_METADATA    = var.custom_metadata
     CUSTOM_CSV_HEADER  = var.custom_csv_header
+    NO_COLOR           = 1
   }
   s3_existing_package = {
     bucket = var.custom_s3_bucket == "" ? "coralogix-serverless-repo-${data.aws_region.this.name}" : var.custom_s3_bucket


### PR DESCRIPTION
# Description

The tracing library that coralogix-aws-shipper supports NO_COLOR, which avoids sending ansi control characters to cloudwatch logs. 

Before:

`[2m2024-05-08T18:15:41.991174Z[0m [33m WARN[0m [2mcoralogix_aws_shipper::process[0m[2m:[0m Non Cloudtrail Log Ingested - Skipping - `

After:

`2024-05-08T18:15:41.991174Z  WARN coralogix_aws_shipper::process: Non Cloudtrail Log Ingested - Skipping - `

* [tracing library pr](https://github.com/tokio-rs/tracing/pull/2647)

* [NO_COLOR](https://no-color.org/)

# How Has This Been Tested?

You can set `NO_COLOR` to `1` in your lambda and see that the control characters are no longer present in cloudwatch logs.

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)