### PR TITLE
Update ID lists to be empty

### DIFF
--- a/examples/cloudwatch-logs/variables.tf
+++ b/examples/cloudwatch-logs/variables.tf
@@ -99,13 +99,13 @@ variable "layer_arn" {
 variable "subnet_ids" {
   description = "The subnet id with the private link"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "security_group_ids" {
   description = "The security group id for assigned to the subnet_ids"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "custom_s3_bucket" {

--- a/modules/cloudwatch-logs/variables.tf
+++ b/modules/cloudwatch-logs/variables.tf
@@ -99,13 +99,13 @@ variable "layer_arn" {
 variable "subnet_ids" {
   description = "The subnet id with the private link"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "security_group_ids" {
   description = "The security group id for assigned to the subnet_ids"
   type        = list(string)
-  default     = [""]
+  default     = []
 }
 
 variable "custom_s3_bucket" {


### PR DESCRIPTION
When using `modules/cloudwatch-logs` the `module "lambda"` could have constant churn because of the possible introduction of `""` in the list of `vpc_subnet_ids` and `vpc_security_group_ids`

# Description

When using `modules/cloudwatch-logs` the `module "lambda"` could have constant churn because of the possible introduction of `""` in the list of `vpc_subnet_ids` and `vpc_security_group_ids`

# How Has This Been Tested?

I used my branch and ran against the churning issue. Screenshots have been added to PR as well.

#### Before
<img width="1647" alt="before" src="https://github.com/coralogix/terraform-coralogix-aws/assets/12501773/7f2b583a-8b59-4ecc-8774-412c24283c52">

#### After
<img width="2625" alt="after" src="https://github.com/coralogix/terraform-coralogix-aws/assets/12501773/ec99a0eb-b682-4ea3-b0a8-8c80f463727d">


# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)
  - This isn't a readme change, but it should have no negative effects that I can fathom. 