### PR TITLE
Sort variables in modules resoruce-metadata and coralogix-aws-shipper modules

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -1,7 +1,7 @@
 name: Changelog
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
     branches: [master]
     paths:
       - "modules/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.0.103
+#### **resource-metadata**
+### 💡 Enhancements 
+### 🛑 Breaking changes 🛑
+- Update variables: `collect_aliases` and `create_secret` to be type `bool` instead of `string`.
+- Update lambda runtime from nodejs18 to nodejs20
+
+## v1.0.102
+#### **coralogix-aws-shipper**
+### 🧰 Bug fixes 🧰
+- Add new parameter runtime, to allow users to specify lambda run time, possible options: `provided.al2023` or `provided.al2` 
+
 ## v1.0.101
 #### **coralogix-aws-shipper**
 ### 💡 Enhancements 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## v1.0.103
 #### **resource-metadata**
 ### 💡 Enhancements 
+- Update lambda runtime from nodejs18 to nodejs20
 ### 🛑 Breaking changes 🛑
 - Update variables: `collect_aliases` and `create_secret` to be type `bool` instead of `string`.
-- Update lambda runtime from nodejs18 to nodejs20
 
 ## v1.0.102
 #### **coralogix-aws-shipper**

--- a/examples/coralogix-aws-shipper/README.md
+++ b/examples/coralogix-aws-shipper/README.md
@@ -1,4 +1,4 @@
-# coralogix-aws-shipper (Beta)
+# coralogix-aws-shipper
 
 Coralogix provides a predefined AWS Lambda function to easily forward your logs to the Coralogix platform.
 

--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -83,6 +83,24 @@ variable "custom_csv_header" {
   default     = null
 }
 
+variable "integration_info" {
+  description = "Values of s3 integraion in case that you want to deploy more than one integration"
+  type = map(object({
+    s3_key_prefix        = optional(string)
+    s3_key_suffix        = optional(string)
+    application_name     = string
+    subsystem_name       = string
+    integration_type     = string
+    lambda_name          = optional(string)
+    newline_pattern      = optional(string)
+    blocking_pattern     = optional(string)
+    lambda_log_retention = optional(number)
+    api_key              = string
+    store_api_key_in_secrets_manager = optional(bool)
+  }))
+  default = null
+}
+
 # cloudwatch variables
 
 variable "log_groups" {
@@ -95,6 +113,70 @@ variable "log_group_prefix" {
   description = "Prefix of the CloudWatch log groups that will trigger the lambda"
   type        = list(string)
   default     = null
+}
+
+# kinesis variables 
+
+variable "kinesis_stream_name" {
+  description = "The name of Kinesis stream to subscribe to retrieving messages"
+  type        = string
+  default     = null
+}
+
+# MSK variables
+
+variable "msk_cluster_arn" {
+  description = "The ARN of the MSK cluster to subscribe to retrieving messages"
+  type        = string
+  default     = null
+}
+
+variable "msk_topic_name" {
+  description = "List of names of the Kafka topic used to store records in your Kafka cluster ( [\"topic1\", \"topic2\",])"
+  type        = list(any)
+  default     = null
+}
+
+# Kafka variables
+
+variable "kafka_brokers" {
+  description = "Comma Delimited List of Kafka broker to connect to"
+  type        = string
+  default     = null
+}
+
+variable "kafka_topic" {
+  description = "The name of the Kafka topic used to store records in your Kafka cluster"
+  type        = string
+  default     = null
+}
+
+variable "kafka_subnets_ids" {
+  description = "List of Kafka subnets to use when connecting to Kafka"
+  type        = list(string)
+  default     = null
+}
+
+variable "kafka_security_groups" {
+  description = "List of Kafka security groups to use when connecting to Kafka"
+  type        = list(string)
+  default     = null
+}
+
+# sqs variables
+
+variable "sqs_name" {
+  description = "The name of the SQS that you want watch"
+  type        = string
+  default     = null
+}
+
+# sns variables
+
+variable "sns_topic_name" {
+  description = "The name of your SNS topic"
+  type        = string
+  default     = ""
 }
 
 # vpc variables
@@ -115,40 +197,6 @@ variable "create_endpoint" {
   description = "Create a VPC endpoint for the lambda function to allow if access to the secret"
   type        = bool
   default     = false
-}
-
-# Lambda configuration
-
-variable "memory_size" {
-  description = "Lambda function memory limit"
-  type        = number
-  default     = 1024
-}
-
-variable "timeout" {
-  description = "Lambda function timeout limit"
-  type        = number
-  default     = 300
-}
-
-variable "runtime" {
-  description = "Lambda function runtime"
-  type        = string
-  default     = "provided.al2023"
-  validation {
-    condition     = contains(["provided.al2023", "provided.al2"], var.runtime)
-    error_message = "The supported runtime are: [provided.al2023, provided.al2]."
-  }
-}
-
-variable "cpu_arch" {
-  description = "Lambda function CPU architecture"
-  type        = string
-  default     = "arm64"
-  validation {
-    condition     = contains(["arm64", "x86_64"], var.cpu_arch)
-    error_message = "The CPU architecture must be one of these values: [arm64, x86_64]."
-  }
 }
 
 # DLQ configuration
@@ -175,6 +223,30 @@ variable "dlq_s3_bucket" {
   description = "The S3 bucket to store the DLQ failed messages after retry limit is reached"
   type        = string
   default     = null
+}
+
+# Lambda configuration
+
+variable "memory_size" {
+  description = "Lambda function memory limit"
+  type        = number
+  default     = 1024
+}
+
+variable "timeout" {
+  description = "Lambda function timeout limit"
+  type        = number
+  default     = 300
+}
+
+variable "cpu_arch" {
+  description = "Lambda function CPU architecture"
+  type        = string
+  default     = "arm64"
+  validation {
+    condition     = contains(["arm64", "x86_64"], var.cpu_arch)
+    error_message = "The CPU architecture must be one of these values: [arm64, x86_64]."
+  }
 }
 
 # Integration Generic Config (Optional)
@@ -229,28 +301,10 @@ variable "integration_type" {
   default = ""
 }
 
-variable "sns_topic_name" {
-  description = "The name of your SNS topic"
-  type        = string
-  default     = ""
-}
-
 variable "store_api_key_in_secrets_manager" {
   description = "Store the API key in AWS Secrets Manager. ApiKeys are stored in secret manager \nby default. If this option is set to false, the ApiKey will appear in plain text as an \n environment variable in the lambda function console."
   type        = bool
   default     = true
-}
-
-variable "sqs_name" {
-  description = "The name of the SQS that you want watch"
-  type        = string
-  default     = null
-}
-
-variable "kinesis_stream_name" {
-  description = "The name of Kinesis stream to subscribe to retrieving messages"
-  type        = string
-  default     = null
 }
 
 variable "add_metadata" {
@@ -263,62 +317,4 @@ variable "custom_metadata" {
   default     = null
   description = "Add custom metadata to the log message. Expects comma separated values. Options are key1=value1,key2=value2 "
   type        = string
-}
-
-variable "integration_info" {
-  description = "Values of s3 integraion in case that you want to deploy more than one integration"
-  type = map(object({
-    s3_key_prefix        = optional(string)
-    s3_key_suffix        = optional(string)
-    application_name     = string
-    subsystem_name       = string
-    integration_type     = string
-    lambda_name          = optional(string)
-    newline_pattern      = optional(string)
-    blocking_pattern     = optional(string)
-    lambda_log_retention = optional(number)
-    api_key              = string
-    store_api_key_in_secrets_manager = optional(bool)
-  }))
-  default = null
-}
-
-# MSK variables
-
-variable "msk_cluster_arn" {
-  description = "The ARN of the MSK cluster to subscribe to retrieving messages"
-  type        = string
-  default     = null
-}
-
-variable "msk_topic_name" {
-  description = "List of names of the Kafka topic used to store records in your Kafka cluster ( [\"topic1\", \"topic2\",])"
-  type        = list(any)
-  default     = null
-}
-
-# Kafka variables
-
-variable "kafka_brokers" {
-  description = "Comma Delimited List of Kafka broker to connect to"
-  type        = string
-  default     = null
-}
-
-variable "kafka_topic" {
-  description = "The name of the Kafka topic used to store records in your Kafka cluster"
-  type        = string
-  default     = null
-}
-
-variable "kafka_subnets_ids" {
-  description = "List of Kafka subnets to use when connecting to Kafka"
-  type        = list(string)
-  default     = null
-}
-
-variable "kafka_security_groups" {
-  description = "List of Kafka security groups to use when connecting to Kafka"
-  type        = list(string)
-  default     = null
 }

--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -239,6 +239,16 @@ variable "timeout" {
   default     = 300
 }
 
+variable "runtime" {
+  description = "Lambda function runtime"
+  type        = string
+  default     = "provided.al2023"
+  validation {
+    condition     = contains(["provided.al2023", "provided.al2"], var.runtime)
+    error_message = "The supported runtime are: [provided.al2023, provided.al2]."
+  }
+}
+
 variable "cpu_arch" {
   description = "Lambda function CPU architecture"
   type        = string

--- a/examples/resource-metadata/variables.tf
+++ b/examples/resource-metadata/variables.tf
@@ -81,8 +81,8 @@ variable "package_name" {
 
 variable "collect_aliases" {
   description = "Collect Aliases"
-  type        = string
-  default     = "False"
+  type        = bool
+  default     = false
 }
 
 variable "lambda_function_include_regex_filter" {
@@ -117,8 +117,8 @@ variable "custom_s3_bucket" {
 
 variable "create_secret" {
   description = "Set to False In case you want to use secrets manager with a predefine secret that was already created and contains Coralogix Send Your Data API key"
-  type        = string
-  default     = "True"
+  type        = bool
+  default     = true
 }
 
 variable "cloudwatch_logs_retention_in_days" {

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -81,7 +81,7 @@ If you want to avoid this issue, you can deploy in other ways:
 | Name | Description | Type | Default | Required | 
 |------|-------------|------|---------|:--------:|
 | <a name="input_log_groups"></a> [log\_groups](#input\_log\_groups) | Provide a comma-separated list of CloudWatch log group names to monitor, for example, (log-group1, log-group2, log-group3). | `list(string)` | n/a | yes |
-| <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) | Prefix of the CloudWatch log groups that will trigger the lambda, in case that your log groups are `log-group1, log-group2, log-group3` then you can set the value to `log-group`. When using this variable you will not be able to see the log groups as trigger for the lambda. | `list(string)` | n/a | no |
+| <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) | Instead of creating one permission for each log group in the destination lambda, the code will take the prefix that you set in this parameter and create 1 permission for all of the log groups that match the prefix, for example if you will define `/aws/log/logs` than the lambda will create only 1 permission for all of your log groups that start with `/aws/log/logs` instead of 1 permision for each of the log group. use this parameter when you have more than 50 log groups. Pay attention that you will not see the log groups as a trigger in the lambda if you use this parameter. | `list(string)` | n/a | no |
 
 ### SNS Configuration
 

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -83,6 +83,24 @@ variable "custom_csv_header" {
   default     = null
 }
 
+variable "integration_info" {
+  description = "Values of s3 integraion in case that you want to deploy more than one integration"
+  type = map(object({
+    s3_key_prefix        = optional(string)
+    s3_key_suffix        = optional(string)
+    application_name     = string
+    subsystem_name       = string
+    integration_type     = string
+    lambda_name          = optional(string)
+    newline_pattern      = optional(string)
+    blocking_pattern     = optional(string)
+    lambda_log_retention = optional(number)
+    api_key              = string
+    store_api_key_in_secrets_manager = optional(bool)
+  }))
+  default = null
+}
+
 # cloudwatch variables
 
 variable "log_groups" {
@@ -95,6 +113,70 @@ variable "log_group_prefix" {
   description = "Prefix of the CloudWatch log groups that will trigger the lambda"
   type        = list(string)
   default     = null
+}
+
+# kinesis variables 
+
+variable "kinesis_stream_name" {
+  description = "The name of Kinesis stream to subscribe to retrieving messages"
+  type        = string
+  default     = null
+}
+
+# MSK variables
+
+variable "msk_cluster_arn" {
+  description = "The ARN of the MSK cluster to subscribe to retrieving messages"
+  type        = string
+  default     = null
+}
+
+variable "msk_topic_name" {
+  description = "List of names of the Kafka topic used to store records in your Kafka cluster ( [\"topic1\", \"topic2\",])"
+  type        = list(any)
+  default     = null
+}
+
+# Kafka variables
+
+variable "kafka_brokers" {
+  description = "Comma Delimited List of Kafka broker to connect to"
+  type        = string
+  default     = null
+}
+
+variable "kafka_topic" {
+  description = "The name of the Kafka topic used to store records in your Kafka cluster"
+  type        = string
+  default     = null
+}
+
+variable "kafka_subnets_ids" {
+  description = "List of Kafka subnets to use when connecting to Kafka"
+  type        = list(string)
+  default     = null
+}
+
+variable "kafka_security_groups" {
+  description = "List of Kafka security groups to use when connecting to Kafka"
+  type        = list(string)
+  default     = null
+}
+
+# sqs variables
+
+variable "sqs_name" {
+  description = "The name of the SQS that you want watch"
+  type        = string
+  default     = null
+}
+
+# sns variables
+
+variable "sns_topic_name" {
+  description = "The name of your SNS topic"
+  type        = string
+  default     = ""
 }
 
 # vpc variables
@@ -115,41 +197,6 @@ variable "create_endpoint" {
   description = "Create a VPC endpoint for the lambda function to allow if access to the secret"
   type        = bool
   default     = false
-}
-
-# Lambda configuration
-
-variable "memory_size" {
-  description = "Lambda function memory limit"
-  type        = number
-  default     = 1024
-}
-
-variable "timeout" {
-  description = "Lambda function timeout limit"
-  type        = number
-  default     = 300
-}
-
-variable "runtime" {
-  description = "Lambda function runtime"
-  type        = string
-  default     = "provided.al2023"
-  default     = "provided.al2023"
-  validation {
-    condition     = contains(["provided.al2023", "provided.al2"], var.runtime)
-    error_message = "The supported runtime are: [provided.al2023, provided.al2]."
-  }
-}
-
-variable "cpu_arch" {
-  description = "Lambda function CPU architecture"
-  type        = string
-  default     = "arm64"
-  validation {
-    condition     = contains(["arm64", "x86_64"], var.cpu_arch)
-    error_message = "The CPU architecture must be one of these values: [arm64, x86_64]."
-  }
 }
 
 # DLQ configuration
@@ -176,6 +223,30 @@ variable "dlq_s3_bucket" {
   description = "The S3 bucket to store the DLQ failed messages after retry limit is reached"
   type        = string
   default     = null
+}
+
+# Lambda configuration
+
+variable "memory_size" {
+  description = "Lambda function memory limit"
+  type        = number
+  default     = 1024
+}
+
+variable "timeout" {
+  description = "Lambda function timeout limit"
+  type        = number
+  default     = 300
+}
+
+variable "cpu_arch" {
+  description = "Lambda function CPU architecture"
+  type        = string
+  default     = "arm64"
+  validation {
+    condition     = contains(["arm64", "x86_64"], var.cpu_arch)
+    error_message = "The CPU architecture must be one of these values: [arm64, x86_64]."
+  }
 }
 
 # Integration Generic Config (Optional)
@@ -230,28 +301,10 @@ variable "integration_type" {
   default = ""
 }
 
-variable "sns_topic_name" {
-  description = "The name of your SNS topic"
-  type        = string
-  default     = ""
-}
-
 variable "store_api_key_in_secrets_manager" {
   description = "Store the API key in AWS Secrets Manager. ApiKeys are stored in secret manager \nby default. If this option is set to false, the ApiKey will appear in plain text as an \n environment variable in the lambda function console."
   type        = bool
   default     = true
-}
-
-variable "sqs_name" {
-  description = "The name of the SQS that you want watch"
-  type        = string
-  default     = null
-}
-
-variable "kinesis_stream_name" {
-  description = "The name of Kinesis stream to subscribe to retrieving messages"
-  type        = string
-  default     = null
 }
 
 variable "add_metadata" {
@@ -264,62 +317,4 @@ variable "custom_metadata" {
   default     = null
   description = "Add custom metadata to the log message. Expects comma separated values. Options are key1=value1,key2=value2 "
   type        = string
-}
-
-variable "integration_info" {
-  description = "Values of s3 integraion in case that you want to deploy more than one integration"
-  type = map(object({
-    s3_key_prefix        = optional(string)
-    s3_key_suffix        = optional(string)
-    application_name     = string
-    subsystem_name       = string
-    integration_type     = string
-    lambda_name          = optional(string)
-    newline_pattern      = optional(string)
-    blocking_pattern     = optional(string)
-    lambda_log_retention = optional(number)
-    api_key              = string
-    store_api_key_in_secrets_manager = optional(bool)
-  }))
-  default = null
-}
-
-# MSK variables
-
-variable "msk_cluster_arn" {
-  description = "The ARN of the MSK cluster to subscribe to retrieving messages"
-  type        = string
-  default     = null
-}
-
-variable "msk_topic_name" {
-  description = "List of names of the Kafka topic used to store records in your Kafka cluster ( [\"topic1\", \"topic2\",])"
-  type        = list(any)
-  default     = null
-}
-
-# Kafka variables
-
-variable "kafka_brokers" {
-  description = "Comma Delimited List of Kafka broker to connect to"
-  type        = string
-  default     = null
-}
-
-variable "kafka_topic" {
-  description = "The name of the Kafka topic used to store records in your Kafka cluster"
-  type        = string
-  default     = null
-}
-
-variable "kafka_subnets_ids" {
-  description = "List of Kafka subnets to use when connecting to Kafka"
-  type        = list(string)
-  default     = null
-}
-
-variable "kafka_security_groups" {
-  description = "List of Kafka security groups to use when connecting to Kafka"
-  type        = list(string)
-  default     = null
 }

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -239,6 +239,16 @@ variable "timeout" {
   default     = 300
 }
 
+variable "runtime" {
+  description = "Lambda function runtime"
+  type        = string
+  default     = "provided.al2023"
+  validation {
+    condition     = contains(["provided.al2023", "provided.al2"], var.runtime)
+    error_message = "The supported runtime are: [provided.al2023, provided.al2]."
+  }
+}
+
 variable "cpu_arch" {
   description = "Lambda function CPU architecture"
   type        = string

--- a/modules/resource-metadata/variables.tf
+++ b/modules/resource-metadata/variables.tf
@@ -81,8 +81,8 @@ variable "package_name" {
 
 variable "collect_aliases" {
   description = "Collect Aliases"
-  type        = string
-  default     = "False"
+  type        = bool
+  default     = false
 }
 
 variable "lambda_function_include_regex_filter" {
@@ -117,8 +117,8 @@ variable "custom_s3_bucket" {
 
 variable "create_secret" {
   description = "Set to False In case you want to use secrets manager with a predefine secret that was already created and contains Coralogix Send Your Data API key"
-  type        = string
-  default     = "True"
+  type        = bool
+  default     = true
 }
 
 variable "cloudwatch_logs_retention_in_days" {


### PR DESCRIPTION
# Description
- Sort variables in coralogix-aws-shipper module
- Update `collect_aliases` and `create_secret` variables in the resource-metadata module to be bool type instead of string
- Rewrite the definition for variable `log_group_prefix`
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)