### PR TITLE
Add ap3 region to shipper and archive integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.0.106
+#### **msk-data-stream**
+### 💡 Enhancements 
+- Update coralogix role from `arn:aws:iam::<account-id>:role/msk-access-<region>` to  `arn:aws:iam::<account-id>:role/coralogix-archive-<region>`
+- allow the module to run in AP3 region
+
+#### **coralogix-aws-shipper**
+### 💡 Enhancements 
+- Allow the module to be deployed in AP3
+
+#### **S3-archive**
+### 💡 Enhancements 
+- Allow the module to be deployed in ap-southeast-3 region
+
+
 ## v1.0.105
 #### **firehose-metrics**
 ### 💡 Enhancements 

--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -3,8 +3,8 @@ variable "coralogix_region" {
   description = "The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2]"
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "AP1", "AP2", "US1", "US2", "Custom"], var.coralogix_region)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, AP1, AP2, US1, US2, Custom]."
+    condition     = contains(["EU1", "EU2", "AP1", "AP2", "AP3", "US1", "US2", "Custom"], var.coralogix_region)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, AP1, AP2, AP3, US1, US2, Custom]."
   }
 }
 

--- a/examples/msk-data-stream/outputs.tf
+++ b/examples/msk-data-stream/outputs.tf
@@ -9,3 +9,7 @@ output "security_group_id" {
 output "cluster_arn" {
   value = aws_msk_cluster.coralogix-msk-cluster.arn
 }
+
+output "msk_public_brokesrs" {
+  value = data.aws_msk_cluster.msk_public_brokers.bootstrap_brokers_public_sasl_iam
+}

--- a/examples/msk-data-stream/variables.tf
+++ b/examples/msk-data-stream/variables.tf
@@ -2,8 +2,8 @@ variable "aws_region" {
   type        = string
   description = "The AWS region that you want to create the MSK in, Must be the same as the AWS region where your coralogix account is set"
   validation {
-    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-south-1", "us-east-2", "us-west-2", "custom"], var.aws_region)
-    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2, custom]."
+    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-southeast-3", "ap-south-1", "us-east-2", "us-west-2", "custom"], var.aws_region)
+    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-southeast-3, ap-south-1, us-east-2, us-west-2, custom]."
   }
 }
 
@@ -42,17 +42,4 @@ variable "custom_coralogix_arn" {
   description = "The custom arn for the coralogix role"
   default     = null
   
-}
-
-variable "coraloigx_roles_arn_mapping" {
-  type = map
-  default = {
-      "eu-west-1"      = "arn:aws:iam::625240141681:role/msk-access-eu1"
-      "eu-north-1"     = "arn:aws:iam::625240141681:role/msk-access-eu2"
-      "ap-southeast-1" = "arn:aws:iam::625240141681:role/msk-access-ap2"
-      "ap-south-1"     = "arn:aws:iam::625240141681:role/msk-access-ap1"
-      "us-east-2"      = "arn:aws:iam::625240141681:role/msk-access-us1"
-      "us-west-2"      = "arn:aws:iam::739076534691:role/msk-access-us2"
-      "custom"         = ""
-  }
 }

--- a/examples/s3-archive/varibales.tf
+++ b/examples/s3-archive/varibales.tf
@@ -3,8 +3,8 @@ variable "aws_region" {
   description = "The AWS region that you want to create the S3 bucket, Must be the same as the AWS region where your coralogix account is set"
   default     = ""
   validation {
-    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-south-1", "us-east-2", "us-west-2", ""], var.aws_region)
-    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2]."
+    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-southeast-3", "ap-south-1", "us-east-2", "us-west-2", ""], var.aws_region)
+    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-southeast-3, ap-south-1, us-east-2, us-west-2]."
   }
 }
 

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -41,7 +41,7 @@ If you want to avoid this issue, you can deploy in other ways:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | The Coralogix location region, possible options are [`EU1`, `EU2`, `AP1`, `AP2`, `US1`, `US2`, `Custom`] | `string` | n/a | yes |
+| <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | The Coralogix location region, possible options are [`EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`, `Custom`] | `string` | n/a | yes |
 | <a name="input_custom_domain"></a> [custom_domain](#input\_custom\_domain) | If you choose a custom domain name for your private cluster, Coralogix will send telemetry from the specified address (e.g. custom.coralogix.com) there is no need to add `ingress.` to the domain .| `string` | n/a | no |
 | <a name="input_integration_type"></a> [integration_type](#input\_data\_type) | Choose the AWS service that you wish to integrate with Coralogix. Can be one of: S3, CloudTrail, VpcFlow, CloudWatch, S3Csv, SNS, SQS, Kinesis, CloudFront, MSK, Kafka, EcrScan. | `string` | n/a | yes |
 | <a name="input_api_key"></a> [api\_key](#input\_api_\_key) | The Coralogix Send Your Data - [API Key](https://coralogix.com/docs/send-your-data-api-key/) validates your authenticity. This value can be a direct Coralogix API Key or an AWS Secret Manager ARN containing the API Key.| `string` | n/a | yes |

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -3,8 +3,8 @@ variable "coralogix_region" {
   description = "The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, US1, US2]"
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "AP1", "AP2", "US1", "US2", "Custom"], var.coralogix_region)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, AP1, AP2, US1, US2, Custom]."
+    condition     = contains(["EU1", "EU2", "AP1", "AP2", "AP3", "US1", "US2", "Custom"], var.coralogix_region)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, AP1, AP2, AP3, US1, US2, Custom]."
   }
 }
 

--- a/modules/locals_variables/locals.tf
+++ b/modules/locals_variables/locals.tf
@@ -8,6 +8,7 @@ locals {
     Singapore = "ingress.coralogixsg.com"
     US        = "ingress.coralogix.us"
     US2       = "ingress.cx498.coralogix.com"
+    AP3       = "ap3.coralogix.com"
   }
 
   coralogix_domains = {
@@ -22,6 +23,7 @@ locals {
     US        = "coralogix.us"
     US1       = "coralogix.us"
     US2       = "cx498.coralogix.com"
+    AP3       = "ap3.coralogix.com"
   }
 
   coralogix_url_seffix = "/api/v1/logs"

--- a/modules/provisioning/msk-data-stream/main.tf
+++ b/modules/provisioning/msk-data-stream/main.tf
@@ -198,4 +198,7 @@ resource "null_resource" "enable-msk-public-access" {
   }
 }
 
-
+data "aws_msk_cluster" "msk_public_brokers" {
+  depends_on = [ null_resource.enable-msk-public-access ]
+  cluster_name = var.cluster_name == "coralogix-msk-cluster" ? "coralogix-msk-cluster-${random_string.unique.result}" : var.cluster_name
+}

--- a/modules/provisioning/msk-data-stream/outputs.tf
+++ b/modules/provisioning/msk-data-stream/outputs.tf
@@ -9,3 +9,7 @@ output "security_group_id" {
 output "cluster_arn" {
   value = aws_msk_cluster.coralogix-msk-cluster.arn
 }
+
+output "msk_public_brokesrs" {
+  value = data.aws_msk_cluster.msk_public_brokers.bootstrap_brokers_public_sasl_iam
+}

--- a/modules/provisioning/msk-data-stream/variables.tf
+++ b/modules/provisioning/msk-data-stream/variables.tf
@@ -2,8 +2,8 @@ variable "aws_region" {
   type        = string
   description = "The AWS region that you want to create the MSK in, Must be the same as the AWS region where your coralogix account is set"
   validation {
-    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-south-1", "us-east-2", "us-west-2", "custom"], var.aws_region)
-    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2, custom]."
+    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1","ap-southeast-3", "ap-south-1", "us-east-2", "us-west-2", "custom"], var.aws_region)
+    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-southeast-3, ap-south-1, us-east-2, us-west-2, custom]."
   }
 }
 
@@ -47,12 +47,13 @@ variable "custom_coralogix_arn" {
 variable "coraloigx_roles_arn_mapping" {
   type = map
   default = {
-      "eu-west-1"      = "arn:aws:iam::625240141681:role/msk-access-eu1"
-      "eu-north-1"     = "arn:aws:iam::625240141681:role/msk-access-eu2"
-      "ap-southeast-1" = "arn:aws:iam::625240141681:role/msk-access-ap2"
-      "ap-south-1"     = "arn:aws:iam::625240141681:role/msk-access-ap1"
-      "us-east-2"      = "arn:aws:iam::625240141681:role/msk-access-us1"
-      "us-west-2"      = "arn:aws:iam::739076534691:role/msk-access-us2"
+      "eu-west-1"      = "arn:aws:iam::625240141681:role/coralogix-archive-eu1"
+      "eu-north-1"     = "arn:aws:iam::625240141681:role/coralogix-archive-eu2"
+      "ap-southeast-1" = "arn:aws:iam::625240141681:role/coralogix-archive-ap2"
+      "ap-south-1"     = "arn:aws:iam::625240141681:role/coralogix-archive-ap1"
+      "us-east-2"      = "arn:aws:iam::625240141681:role/coralogix-archive-us1"
+      "us-west-2"      = "arn:aws:iam::739076534691:role/coralogix-archive-us2"
+      "ap-southeast-3" = "arn:aws:iam::025066248247:role/coralogix-archive-ap3"
       "custom"         = ""
   }
 }

--- a/modules/provisioning/s3-archive/README.md
+++ b/modules/provisioning/s3-archive/README.md
@@ -2,7 +2,7 @@
 
 The module s3-archive will create s3 buckets to archive your coralogix logs and metrics
 
-The module can run only on the following regions eu-west-1,eu-north-1,ap-southeast-1,ap-south-1,us-east-2.
+The module can run only on the following regions eu-west-1,eu-north-1,ap-southeast-1,ap-southeast-3,ap-south-1,us-east-2.
 
 ## Requirements
 
@@ -19,7 +19,7 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 
 | Variable name | Description | Type | Default | Required | 
 |------|-------------|------|------|:--------:|
-| aws_region | The AWS region that you want to create the S3 bucket, Must be the same as the AWS region where your [coralogix account](https://coralogix.com/docs/coralogix-domain/) is set. Allowd values: eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2 | `string` | n/a | :heavy_check_mark: |
+| aws_region | The AWS region that you want to create the S3 bucket, Must be the same as the AWS region where your [coralogix account](https://coralogix.com/docs/coralogix-domain/) is set. Allowd values: eu-west-1, eu-north-1, ap-southeast-1,ap-southeast-1, ap-south-1, us-east-2, us-west-2 | `string` | n/a | :heavy_check_mark: |
 | logs_bucket_name | The name of the S3 bucket to create for the logs archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | `string` | n/a | |
 | metrics_bucket_name | The name of the S3 bucket to create for the metrics archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | `string` | n/a | |
 | logs_kms_arn |  The arn of your kms for the logs bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |

--- a/modules/provisioning/s3-archive/variables.tf
+++ b/modules/provisioning/s3-archive/variables.tf
@@ -3,8 +3,8 @@ variable "aws_region" {
   description = "The AWS region that you want to create the S3 bucket, Must be the same as the AWS region where your coralogix account is set"
   default     = ""
   validation {
-    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-south-1", "us-east-2", "us-west-2", ""], var.aws_region)
-    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2]."
+    condition     = contains(["eu-west-1", "eu-north-1", "ap-southeast-1", "ap-southeast-3", "ap-south-1", "us-east-2", "us-west-2", ""], var.aws_region)
+    error_message = "The aws region must be one of these values: [eu-west-1, eu-north-1, ap-southeast-1, ap-southeast-3, ap-south-1, us-east-2, us-west-2]."
   }
 }
 
@@ -26,6 +26,7 @@ variable "coralogix_arn_mapping" {
     "eu-west-1"          = "625240141681"
     "eu-north-1"         = "625240141681"
     "ap-southeast-1"     = "625240141681"
+    "ap-southeast-3"     = "025066248247"
     "ap-south-1"         = "625240141681"
     "us-east-2"          = "625240141681"
     "us-west-2"          = "739076534691"
@@ -66,6 +67,7 @@ variable "aws_role_region"  {
       "ap-south-1"="ap1"
       "us-east-2"="us1"
       "us-west-2"="us2"
+      "ap-southeast-3"="ap3"
     }
   }
   


### PR DESCRIPTION
# Description
Add option to run the following modules in new region AP3: coralogix-aws-shipper, S3-archive, msk-data-stream
Update the msk-data-stream role and add output to the public brokers
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)