### PR TITLE
fix: Allow force destroy and random string in bucket name [CDS-1505]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
+## v2.1.1
+#### **S3-archive**
+### 🧰 Bug fixes 🧰 
+- Add `logs_bucket_force_destroy` and `metrics_bucket_force_destroy` variables to allow force destroy the bucekts.
+
 ## v2.1.0
+#### **firehose-metrics**
 ### 💡 Enhancements 
 - Added an option to include metrics from source accounts linked to the monitoring account in the Firehose CloudWatch metric stream.
 - Introduced the `include_linked_accounts_metrics` variable to control the inclusion of linked account metrics for Firehose.
 - Updated example configurations to demonstrate usage of the `include_linked_accounts_metrics` variable in Firehose metric streams.
 
 ## v2.0.1
+#### **ecs-ec2**
 ### 🧰 Bug fixes 🧰
 - Fixed ecs-ec2 module, adjusted cdot image command to `--config env:OTEL_CONFIG`
 - Removed latest flag from ecs-ec2 module example.
@@ -14,7 +21,6 @@
 
 ### 💡 Enhancements 
 - Added pprof extension to default ecs-ec2 otel configurations.
-
 
 ## v2.0.0
 ### 🛑 Breaking changes 🛑

--- a/examples/s3-archive/outputs.tf
+++ b/examples/s3-archive/outputs.tf
@@ -1,7 +1,3 @@
-output "bucket_name_same" {
-  value = local.is_same_bucket_name ? "Logs and Metrics bucket name should not be the same" : ""
-}
-
 output "wrong_region" {
   value = local.is_valid_region ? "" : "You tried to configure the bucket in a region that is not supported, or you are not in the region that you specified. Allow regions: eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2"
 }

--- a/examples/s3-archive/variables.tf
+++ b/examples/s3-archive/variables.tf
@@ -20,19 +20,6 @@ variable "custom_coralogix_arn" {
   default     = ""
 }
 
-variable "coralogix_arn_mapping" {
-  type = map(string)
-  default = {
-    "eu-west-1"          = "625240141681"
-    "eu-north-1"         = "625240141681"
-    "ap-southeast-1"     = "625240141681"
-    "ap-south-1"         = "625240141681"
-    "us-east-2"          = "625240141681"
-    "us-west-2"          = "739076534691"
-    ""                   = "625240141681"
-  }
-}
-
 variable "logs_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to create for the logs archive (Leave empty if not needed)"
@@ -57,15 +44,14 @@ variable "metrics_kms_arn" {
   default     = ""
 }
 
-variable "aws_role_region"  {
-  type = map
-  default = {
-      "eu-west-1"="eu1"
-      "eu-north-1"="eu2"
-      "ap-southeast-1"="ap1"
-      "ap-south-1"="ap2"
-      "us-east-2"="us1"
-      "us-west-2"="us2"
-    }
-  }
-  
+variable "logs_bucket_force_destroy" {
+  type        = bool
+  description = "force the metrics bucket to destroyed, even if there is data in it"
+  default     = false
+}
+
+variable "metrics_bucket_force_destroy" {
+  type        = bool
+  description = "force the metrics bucket to destroyed, even if there is data in it"
+  default     = false
+}

--- a/examples/s3-archive/variables.tf
+++ b/examples/s3-archive/variables.tf
@@ -23,13 +23,13 @@ variable "custom_coralogix_arn" {
 variable "logs_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to create for the logs archive (Leave empty if not needed)"
-  default     = ""
+  default     = null
 }
 
 variable "metrics_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to create for the metrics archive (Leave empty if not needed)"
-  default     = ""
+  default     = null
 }
 
 variable "logs_kms_arn" {

--- a/modules/provisioning/s3-archive/README.md
+++ b/modules/provisioning/s3-archive/README.md
@@ -18,9 +18,11 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.15.1 |
 
 | Variable name | Description | Type | Default | Required | 
-|------|-------------|------|------|:--------:|
+|---------------|-------------|------|---------|:--------:|
 | aws_region | The AWS region that you want to create the S3 bucket, Must be the same as the AWS region where your [coralogix account](https://coralogix.com/docs/coralogix-domain/) is set. Allowd values: eu-west-1, eu-north-1, ap-southeast-1,ap-southeast-1, ap-south-1, us-east-2, us-west-2 | `string` | n/a | :heavy_check_mark: |
 | logs_bucket_name | The name of the S3 bucket to create for the logs archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | `string` | n/a | |
 | metrics_bucket_name | The name of the S3 bucket to create for the metrics archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | `string` | n/a | |
+| logs_bucket_force_destroy | enable force destroy to the logs S3 bucekt, to not allow delete if there is files in the bucket | `bool` | false | |
+| metrics_bucket_force_destroy | enable force destroy to the metrics S3 bucekt, to not allow delete if there is files in the bucket | `bool` | false | |
 | logs_kms_arn |  The arn of your kms for the logs bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |
 | metrics_kms_arn | The arn of your kms for the metrics bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |

--- a/modules/provisioning/s3-archive/main.tf
+++ b/modules/provisioning/s3-archive/main.tf
@@ -1,12 +1,9 @@
 locals {
-  is_logs_bucket_name_empty    = var.logs_bucket_name != ""
-  is_metrics_bucket_name_empty = var.metrics_bucket_name != ""
-  is_same_bucket_name          = var.logs_bucket_name == var.metrics_bucket_name
   is_valid_region              = data.aws_region.current.name == var.aws_region
   coralogix_role_region        = lookup(var.aws_role_region, var.aws_region)
 
-  logs_validations       = local.is_logs_bucket_name_empty && !local.is_same_bucket_name && (local.is_valid_region || var.bypass_valid_region != "")
-  metrics_validations    = local.is_metrics_bucket_name_empty && !local.is_same_bucket_name && (local.is_valid_region || var.bypass_valid_region != "")
+  logs_validations       = local.is_valid_region || var.bypass_valid_region != ""
+  metrics_validations    = local.is_valid_region || var.bypass_valid_region != ""
   kms_logs_validation    = local.logs_validations && var.logs_kms_arn != "" && contains(split(":", var.logs_kms_arn), var.aws_region)
   kms_metrics_validation = local.metrics_validations && var.metrics_kms_arn != "" && contains(split(":", var.metrics_kms_arn), var.aws_region)
   coralogix_log_role_arn = var.custom_coralogix_arn != "" ? "arn:aws:iam::${var.custom_coralogix_arn}:role/coralogix-archive-${local.coralogix_role_region}" : var.bypass_valid_region != "" ? "arn:aws:iam::${var.coralogix_arn_mapping[""]}:role/coralogix-archive-${local.coralogix_role_region}" : "arn:aws:iam::${var.coralogix_arn_mapping[var.aws_region]}:role/coralogix-archive-${local.coralogix_role_region}"
@@ -18,17 +15,13 @@ data "aws_region" "current" {}
 resource "aws_s3_bucket" "logs_bucket_name" {
   count  = local.logs_validations ? 1 : 0
   bucket = var.logs_bucket_name
-  lifecycle {
-    prevent_destroy = true
-  }
+  force_destroy = var.logs_bucket_force_destroy
 }
 
 resource "aws_s3_bucket" "metrics_bucket_name" {
   count  = local.metrics_validations ? 1 : 0
   bucket = var.metrics_bucket_name
-  lifecycle {
-    prevent_destroy = true
-  }
+  force_destroy = var.metrics_bucket_force_destroy
 }
 
 resource "aws_s3_bucket_policy" "logs_bucket_policy" {

--- a/modules/provisioning/s3-archive/main.tf
+++ b/modules/provisioning/s3-archive/main.tf
@@ -1,9 +1,12 @@
 locals {
+  is_logs_bucket_name_empty    = var.logs_bucket_name != null
+  is_metrics_bucket_name_empty = var.metrics_bucket_name != null
+  is_same_bucket_name          = var.logs_bucket_name == var.metrics_bucket_name
   is_valid_region              = data.aws_region.current.name == var.aws_region
   coralogix_role_region        = lookup(var.aws_role_region, var.aws_region)
 
-  logs_validations       = local.is_valid_region || var.bypass_valid_region != ""
-  metrics_validations    = local.is_valid_region || var.bypass_valid_region != ""
+  logs_validations       = local.is_logs_bucket_name_empty && !local.is_same_bucket_name && (local.is_valid_region || var.bypass_valid_region != "")
+  metrics_validations    = local.is_metrics_bucket_name_empty && !local.is_same_bucket_name && (local.is_valid_region || var.bypass_valid_region != "")
   kms_logs_validation    = local.logs_validations && var.logs_kms_arn != "" && contains(split(":", var.logs_kms_arn), var.aws_region)
   kms_metrics_validation = local.metrics_validations && var.metrics_kms_arn != "" && contains(split(":", var.metrics_kms_arn), var.aws_region)
   coralogix_log_role_arn = var.custom_coralogix_arn != "" ? "arn:aws:iam::${var.custom_coralogix_arn}:role/coralogix-archive-${local.coralogix_role_region}" : var.bypass_valid_region != "" ? "arn:aws:iam::${var.coralogix_arn_mapping[""]}:role/coralogix-archive-${local.coralogix_role_region}" : "arn:aws:iam::${var.coralogix_arn_mapping[var.aws_region]}:role/coralogix-archive-${local.coralogix_role_region}"

--- a/modules/provisioning/s3-archive/outputs.tf
+++ b/modules/provisioning/s3-archive/outputs.tf
@@ -1,7 +1,3 @@
-output "bucket_name_same" {
-  value = local.is_same_bucket_name ? "Logs and Metrics bucket name should not be the same" : ""
-}
-
 output "wrong_region" {
   value = local.is_valid_region ? "" : "You tried to configure the bucket in a region that is not supported, or you are not in the region that you specified. Allow regions: eu-west-1, eu-north-1, ap-southeast-1, ap-south-1, us-east-2, us-west-2"
 }

--- a/modules/provisioning/s3-archive/variables.tf
+++ b/modules/provisioning/s3-archive/variables.tf
@@ -37,13 +37,13 @@ variable "coralogix_arn_mapping" {
 variable "logs_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to create for the logs archive (Leave empty if not needed)"
-  default     = ""
+  default     = null
 }
 
 variable "metrics_bucket_name" {
   type        = string
   description = "The name of the S3 bucket to create for the metrics archive (Leave empty if not needed)"
-  default     = ""
+  default     = null
 }
 
 variable "logs_kms_arn" {

--- a/modules/provisioning/s3-archive/variables.tf
+++ b/modules/provisioning/s3-archive/variables.tf
@@ -58,6 +58,18 @@ variable "metrics_kms_arn" {
   default     = ""
 }
 
+variable "logs_bucket_force_destroy" {
+  type        = bool
+  description = "force the metrics bucket to destroyed, even if there is data in it"
+  default     = false
+}
+
+variable "metrics_bucket_force_destroy" {
+  type        = bool
+  description = "force the metrics bucket to destroyed, even if there is data in it"
+  default     = false
+}
+
 variable "aws_role_region"  {
   type = map
   default = {


### PR DESCRIPTION
# Description
Remove validation for the bucket names to allow users to use random string in the bucket name.
Add variables to allow force destroy to the bucket in case it is necessary 

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #104

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)