### PR TITLE
fix: changed resource arn if integration is deployed from govcloud [CDS-1667]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.1.2
+#### **coralogix-aws-shipper**
+### 🧰 Bug fixes 🧰 
+- Add new variable `govcloud_deployment`, when set to true the arn of resource that are being used by the module will start with `arn:aws-us-gov` instead of `arn:aws`
+- Add a condition to the `aws_iam_policy.AWSLambdaMSKExecutionRole` block so it will only create it when MSK is enabled
+
 ## v2.1.1
 #### **S3-archive**
 ### 🧰 Bug fixes 🧰 

--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -328,3 +328,9 @@ variable "custom_metadata" {
   description = "Add custom metadata to the log message. Expects comma separated values. Options are key1=value1,key2=value2 "
   type        = string
 }
+
+variable "govcloud_deployment" {
+  description = "Enable if you deploy the integration in govcloud"
+  type        = bool
+  default     = false
+}

--- a/modules/coralogix-aws-shipper/Msk.tf
+++ b/modules/coralogix-aws-shipper/Msk.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy" "destination_policy" {
 resource "aws_iam_role_policy_attachment" "msk-role-policy-attach" {
   count      = var.msk_cluster_arn != null ? 1 : 0
   role       = aws_iam_role.role_for_msk[0].name
-  policy_arn = data.aws_iam_policy.AWSLambdaMSKExecutionRole.arn
+  policy_arn = data.aws_iam_policy.AWSLambdaMSKExecutionRole[0].arn
 }
 
 resource "aws_lambda_event_source_mapping" "msk_event_mapping" {

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -128,6 +128,7 @@ If you want to avoid this issue, you can deploy in other ways:
 | <a name="input_sampling_rate"></a> [sampling\_rate](#input\_sampling\_rate) | Send messages at a specific rate, such as 1 out of every N logs. For example, if your value is 10, a message will be sent for every 10th log. | `number` | `1` | no |
 | <a name="input_notification_email"></a> [notification_email](#input\_notification\_email) | A failure notification will be sent to this email address. | `string` |  n/a | no |
 | <a name="input_custom_s3_bucket"></a> [custom\_s3\_bucket](#input\_custom\_s3\_bucket) | The name of an existing s3 bucket in your region, in which the lambda zip code will be uploaded to. | `string` | n/a | no |
+| <a name="input_govcloud_deployment"></a> [govcloud\_deployment](#input\_govcloud\_deployment) | Enable if you deploy the integration in govcloud | `bool` | false | no |
 
 **Custom S3 Bucket**
 

--- a/modules/coralogix-aws-shipper/data.tf
+++ b/modules/coralogix-aws-shipper/data.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "topic" {
     }
 
     actions   = local.sns_enable ? ["SNS:Publish"] : ["SQS:SendMessage"]
-    resources = local.sns_enable ? ["arn:aws:sns:*:*:${data.aws_sns_topic.sns_topic[count.index].name}"] : ["arn:aws:sqs:*:*:${data.aws_sqs_queue.name[count.index].name}"]
+    resources = local.sns_enable ? ["${local.arn_prefix}:sns:*:*:${data.aws_sns_topic.sns_topic[count.index].name}"] : ["${local.arn_prefix}:sqs:*:*:${data.aws_sqs_queue.name[count.index].name}"]
 
     condition {
       test     = "ArnLike"
@@ -59,5 +59,6 @@ data "aws_iam_policy_document" "topic" {
 }
 
 data "aws_iam_policy" "AWSLambdaMSKExecutionRole" {
-  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole"
+  count = var.msk_cluster_arn != null ? 1 : 0
+  arn   = "${local.arn_prefix}:iam::aws:policy/service-role/AWSLambdaMSKExecutionRole"
 }

--- a/modules/coralogix-aws-shipper/local.tf
+++ b/modules/coralogix-aws-shipper/local.tf
@@ -39,4 +39,5 @@ locals {
   is_sns_integration = local.sns_enable && (var.integration_type == "S3" || var.integration_type == "Sns" || var.integration_type == "CloudTrail") ? true : false
   is_sqs_integration = var.sqs_name != null && (var.integration_type == "S3" || var.integration_type == "CloudTrail" || var.integration_type == "Sqs") ? true : false
 
+  arn_prefix = var.govcloud_deployment ? "arn:aws-us-gov" : "arn:aws"
 }

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -279,6 +279,12 @@ variable "custom_s3_bucket" {
   default     = ""
 }
 
+variable "govcloud_deployment" {
+  description = "Enable if you deploy the integration in govcloud"
+  type        = bool
+  default     = false
+}
+
 variable "lambda_name" {
   type        = string
   description = "The name of the lambda function"


### PR DESCRIPTION
# Description
Add new variable govcloud_deployment to enable in case that the integration is being deploy from govcloud, if enable arn for resource in the template will use `arn:aws-us-gov` instead of `arn:aws`.
Add condition for the  aws_iam_policy.AWSLambdaMSKExecutionRole resource so it will only create it in case that msk is enabled 
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)