### PR TITLE
fix: remove breaking line from otelcol config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.1
+#### **ecs-ec2**
+### 🧰 Bug fixes 🧰
+- Removed `default` key from `json_parser` operator, because the operator doesn't have this key, and the opentelemetry config failed because of it
+
 ## v2.3.0
 #### **coralogix-aws-shipper**
 ### 💡 Enhancements 

--- a/modules/ecs-ec2/otel_config.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config.tftpl.yaml
@@ -35,7 +35,6 @@ receivers:
         timestamp:
           parse_from: body.time
           layout: '%Y-%m-%dT%H:%M:%S.%fZ'
-        default: move_log_file_path
 
       # handle logs split by docker
       - type: recombine

--- a/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config_metrics.tftpl.yaml
@@ -35,7 +35,6 @@ receivers:
         timestamp:
           parse_from: body.time
           layout: '%Y-%m-%dT%H:%M:%S.%fZ'
-        default: move_log_file_path
 
       # handle logs split by docker
       - type: recombine


### PR DESCRIPTION
# Description

in the middle of my ECS/EKS onboarding tests, and I've found the bug that's causes the default otel config failing

```
Error: failed to get config: cannot unmarshal the configuration: 1 error(s) decoding:

* error decoding 'receivers': error reading configuration for "filelog": 1 error(s) decoding:
* error decoding 'operators[1]': unmarshal to json_parser: 1 error(s) decoding:
* '' has invalid keys: default
```

otelcol claims that the json_parser operator doesn't have the default option/key, and it doesn't start because of it – in fact, it's right, because there is no such option, as I see in [docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/json_parser.md)

router operator has this key, but json_parser doesn't

once I removed this line from the config, things started to work as expected, and all logs/metrics were sent to coralogix 

when I've run the problematic config locally with otelcol-contrib, commenting cdot specials, it didn't give me an error because of this key – so I assume that opentelemetry just ignored such things like invalid keys until some version update, when they've made the syntax more strict

we have to remove this line, which causes the error, from both otelcol config on both terraform&cloudformation setups, so we won't get stuck with this issue in the future

# How Has This Been Tested?

1. Created ECS/EC2 cluster from scratch
2. Deployed the otelcol as terraform module (but otelcol config is the same as in cloudformation tepo)
3. Found that daemonset tasks don't start, then found the error in the instance console
4. Removed the line and updated the task definition
5. Everything went back to normal again