### PR TITLE
fix: fix error with api_key nonsensitive in shipper module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.1
+#### **coralogix-aws-shipper**
+### 🧰 Bug fixes 🧰 
+- Fix issue with local variable `api_key_is_arn` being nonsensitive, for terraform version lower than `1.10.0`
+
 ## v2.3.0
 #### **coralogix-aws-shipper**
 ### 💡 Enhancements 

--- a/modules/coralogix-aws-shipper/local.tf
+++ b/modules/coralogix-aws-shipper/local.tf
@@ -17,7 +17,7 @@ locals {
     group
   } : {}
 
-  api_key_is_arn = nonsensitive(replace(var.api_key, ":", "") != var.api_key ? true : false)
+  api_key_is_arn = replace(nonsensitive(var.api_key), ":", "") != nonsensitive(var.api_key) ? true : false
 
   integration_info = var.integration_info == null ? {
     integration = {


### PR DESCRIPTION
# Description
The previous syntax didn't work for the Terraform version older than 1.10.0, so update the syntax to work for all Terraform versions
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #189 #186 

# How Has This Been Tested?
Deploy the module for terraform 1.10.0 and 1.5.5 with api_key as arn for secret and as the api_key
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)