### PR TITLE
fix: replace deleted private_key in firehose module READMEs

### DIFF
--- a/examples/firehose-metrics/README.md
+++ b/examples/firehose-metrics/README.md
@@ -88,8 +88,8 @@ In this example you need to configure the following variables:
 * `firehose_stream` --> The name of the Firehose Metrics delivery stream
 * `coralogix_region` --> The region of Coralogix account
 * `api_key` --> Coralogix account api_key
-Since the private_key is private and we cant put it hardcoded, it can be exported instead of insert it as an input each time:
-export TF_VAR_private_key="your-coralogix-private-key"
+Since the api_key is private and we cant put it hardcoded, it can be exported instead of insert it as an input each time:
+export TF_VAR_api_key="your-coralogix-api-key"
 * `include_metric_stream_namespaces` --> The list of the the desired namespaces, for example: ["EC2", "DynamoDB"]. For the full list of the available namespaces and how they need to be mentioned, please see [namespaces list](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html)'
 * `include_metric_stream_filter` --> List of inclusive metric filters for namespace and metric_names. For the full list of the available namespaces, please see [namespaces list](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html). To view available metric names of selected namespace, please see [view available metric names](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/viewing_metrics_with_cloudwatch.html)
 * `include_linked_accounts_metrics` --> Include metrics from source accounts that are linked to this monitoring account, please see [CloudWatch cross-account observability](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html).

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -12,7 +12,7 @@ Provision a firehose delivery stream for streaming logs to [Coralogix](https://c
 module "cloudwatch_firehose_logs_coralogix" {
   source                         = "coralogix/aws/coralogix//modules/firehose-logs"
   firehose_stream                = var.coralogix_firehose_stream_name
-  private_key                    = var.private_key
+  api_key                        = var.api_key
   coralogix_region               = var.coralogix_region
   integration_type_logs          = "Default"
   source_type_logs               = "DirectPut"
@@ -87,7 +87,7 @@ It is possible to pass a custom coralogix domain by using the `custom_domain` va
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | Coralogix account region: EU1, EU2, AP1, AP2, AP3, US1, US2 [exact] | `any` | n/a | yes |
-| <a name="input_private_key"></a> [private_key](#input\_private_key) | Coralogix account logs private key | `any` | n/a | yes |
+| <a name="input_api_key"></a> [api_key](#input\_api_key) | Coralogix account logs private key | `any` | n/a | yes |
 | <a name="input_firehose_stream"></a> [firehose\_stream](#input\_firehose\_stream) | AWS Kinesis firehose delivery stream name | `string` | n/a | yes |
 | <a name="input_application_name"></a> [application_name](#input\_application_name) | The name of your application in Coralogix | `string` | n/a | yes |
 | <a name="input_subsystem_name"></a> [subsystem_name](#input\_subsystem_name) | The subsystem name of your application in Coralogix | `string` | n/a | yes |

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -87,7 +87,7 @@ It is possible to pass a custom coralogix domain by using the `custom_domain` va
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | Coralogix account region: EU1, EU2, AP1, AP2, AP3, US1, US2 [exact] | `any` | n/a | yes |
-| <a name="input_api_key"></a> [api_key](#input\_api_key) | Coralogix account logs private key | `any` | n/a | yes |
+| <a name="input_api_key"></a> [api_key](#input\_api_key) | Coralogix account logs API key | `any` | n/a | yes |
 | <a name="input_firehose_stream"></a> [firehose\_stream](#input\_firehose\_stream) | AWS Kinesis firehose delivery stream name | `string` | n/a | yes |
 | <a name="input_application_name"></a> [application_name](#input\_application_name) | The name of your application in Coralogix | `string` | n/a | yes |
 | <a name="input_subsystem_name"></a> [subsystem_name](#input\_subsystem_name) | The subsystem name of your application in Coralogix | `string` | n/a | yes |


### PR DESCRIPTION
# Description

Updated 2 READMEs for `firehose-logs` and `firehose-metrics` modules by replacing `private_key` variable reference by `api_key`. which was done in https://github.com/coralogix/terraform-coralogix-aws/commit/659821dc19c3966d1ffbee21b857933ccc092f15

# How Has This Been Tested?

README changes don't need to be tested besides from `Markdown Preview` check.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [x] This change does not affect module (e.g. it's readme file change)