### PR TITLE
fix - tag missing for aws_kinesis_firehose_delivery_stream resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.4
+#### **firehose-logs**
+### 🧰 Bug fixes 🧰
+- Tag missing for `aws_kinesis_firehose_delivery_stream` resource
+
 ## v2.3.3
 #### **firehose-metrics**
 #### **firehose-logs**

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -174,7 +174,7 @@ resource "aws_iam_role_policy_attachment" "policy_attachment_cloudwatch" {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_logs" {
-  tags        = local.tags
+  tags        = merge(local.tags, { LogDeliveryEnabled = "true" })
   name        = var.firehose_stream
   destination = "http_endpoint"
 


### PR DESCRIPTION

# Description

LogDeliveryEnabled = true, Tag was missing for aws_kinesis_firehose_delivery_stream resource

Fixes  https://github.com/coralogix/terraform-coralogix-aws/issues/194

# How Has This Been Tested?

Tested on my env. by running terraform apply multiple times.

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)