### PR TITLE
fix: decouple IAM policy documents from IAM role resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.3.3
+#### **firehose-metrics**
+#### **firehose-logs**
+### 🧰 Bug fixes 🧰
+- Decouple IAM policy documents from IAM role resource
+
 ## v2.3.2
 #### **ecs-ec2**
 ### 🧰 Bug fixes 🧰

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -157,7 +157,7 @@ data "aws_iam_policy_document" "new_firehose_policy" {
 
 resource "aws_iam_role_policy" "new_firehose_policy" {
   count  = var.existing_firehose_iam != null ? 0 : 1
-  name   = "${local.new_firehose_iam_name}-policy"
+  name   = local.new_firehose_iam_name
   role   = aws_iam_role.new_firehose_iam[0].name
   policy = data.aws_iam_policy_document.new_firehose_policy.json
 }

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -95,63 +95,71 @@ data "aws_iam_role" "existing_firehose_iam" {
 }
 
 resource "aws_iam_role" "new_firehose_iam" {
-  count = var.existing_firehose_iam != null ? 0 : 1
-  tags  = local.tags
-  name  = local.new_firehose_iam_name
-  assume_role_policy = jsonencode({
-    "Version" = "2012-10-17",
-    "Statement" = [
-      {
-        "Action" = "sts:AssumeRole",
-        "Principal" = {
-          "Service" = "firehose.amazonaws.com"
-        },
-        "Effect" = "Allow"
-      }
-    ]
-  })
-  inline_policy {
-    name = local.new_firehose_iam_name
-    policy = jsonencode({
-      "Version" = "2012-10-17",
-      "Statement" = [
-        {
-          "Effect" = "Allow",
-          "Action" = [
-            "s3:AbortMultipartUpload",
-            "s3:GetBucketLocation",
-            "s3:GetObject",
-            "s3:ListBucket",
-            "s3:ListBucketMultipartUploads",
-            "s3:PutObject"
-          ],
-          "Resource" = [
-            "${local.s3_backup_bucket_arn}",
-            "${local.s3_backup_bucket_arn}/*"
-          ]
-        },
-        {
-          "Effect" = "Allow",
-          "Action" = [
-            "kinesis:DescribeStream",
-            "kinesis:GetShardIterator",
-            "kinesis:GetRecords",
-            "kinesis:ListShards"
-          ],
-          "Resource" = "${local.arn_prefix}:kinesis:${data.aws_region.current_region.name}:${data.aws_caller_identity.current_identity.account_id}:stream/*"
-        },
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "logs:PutLogEvents"
-          ],
-          "Resource" : [
-            "${aws_cloudwatch_log_group.firehose_loggroup.arn}"
-          ]
-        }
-      ]
-    })
+  count              = var.existing_firehose_iam != null ? 0 : 1
+  tags               = local.tags
+  name               = local.new_firehose_iam_name
+  assume_role_policy = data.aws_iam_policy_document.assume_new_firehose_iam.json
+}
+
+data "aws_iam_policy_document" "assume_new_firehose_iam" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+
+    effect = "Allow"
   }
+}
+
+data "aws_iam_policy_document" "new_firehose_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+    ]
+    resources = [
+      local.s3_backup_bucket_arn,
+      "${local.s3_backup_bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kinesis:DescribeStream",
+      "kinesis:GetShardIterator",
+      "kinesis:GetRecords",
+      "kinesis:ListShards",
+    ]
+    resources = [
+      "${local.arn_prefix}:kinesis:${data.aws_region.current_region.name}:${data.aws_caller_identity.current_identity.account_id}:stream/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents",
+    ]
+    resources = [
+      aws_cloudwatch_log_group.firehose_loggroup.arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "new_firehose_policy" {
+  count  = var.existing_firehose_iam != null ? 0 : 1
+  name   = "${local.new_firehose_iam_name}-policy"
+  role   = aws_iam_role.new_firehose_iam[0].name
+  policy = data.aws_iam_policy_document.new_firehose_policy.json
 }
 
 # Add additional policies to the firehose IAM role

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -104,21 +104,23 @@ data "aws_iam_role" "existing_firehose_iam" {
 }
 
 resource "aws_iam_role" "new_firehose_iam" {
-  count = var.existing_firehose_iam != null ? 0 : 1
-  tags  = local.tags
-  name  = local.new_firehose_iam_name
-  assume_role_policy = jsonencode({
-    "Version" = "2012-10-17",
-    "Statement" = [
-      {
-        "Action" = "sts:AssumeRole",
-        "Principal" = {
-          "Service" = "firehose.amazonaws.com"
-        },
-        "Effect" = "Allow"
-      }
-    ]
-  })
+  count              = var.existing_firehose_iam != null ? 0 : 1
+  tags               = local.tags
+  name               = local.new_firehose_iam_name
+  assume_role_policy = data.aws_iam_policy_document.assume_new_firehose_iam.json
+}
+
+data "aws_iam_policy_document" "assume_new_firehose_iam" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
 }
 
 resource "aws_iam_policy" "new_firehose_iam" {


### PR DESCRIPTION
# Description

Fixes #193

additionally decouples `assume_role_policy` from IAM role specifications to the separate `data.aws_iam_policy_document` resource

# How Has This Been Tested?

0. Run the module instance via `terraform apply` before the code change to reproduce this warning:

```
│ Warning: Argument is deprecated
│ 
│   with module.cloudwatch_firehose_logs_coralogix.aws_iam_role.new_firehose_iam[0],
│   on .terraform/modules/cloudwatch_firehose_logs_coralogix/modules/firehose-logs/main.tf line 97, in resource "aws_iam_role" "new_firehose_iam":
│   97: resource "aws_iam_role" "new_firehose_iam" {
│ 
│ The inline_policy argument is deprecated. Use the aws_iam_role_policy resource instead. If Terraform should exclusively manage all inline policy associations (the current behavior of this argument), use the aws_iam_role_policies_exclusive resource as well.
```

1. Run `terraform plan` on `firehose-logs` module instance after the code change
2. You will see a new resource Terraform wants to add, run `terraform apply` to see the warning is gone and the new resource has been added without breaking the resource permission

Although terraform will technically create a new resource, practically the state of IAM role altogether with its policy will stay the same as it was before the change: same inline policy format, same name, same permissions. (during `tf apply` it won't return you the error that this policy already exists)

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)