### PR TITLE
feat: s3 deny insecure transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v2.3.5
+## v2.4.0
 #### **firehose-logs**
 ### 💡 Enhancements 💡
 - Added Amazon S3 bucket policies to require encryption during data transit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.3.5
+#### **firehose-logs**
+### 💡 Enhancements 💡
+- Added Amazon S3 bucket policies to require encryption during data transit.
+  
 ## v2.3.4
 #### **firehose-logs**
 ### 🧰 Bug fixes 🧰

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -103,6 +103,7 @@ It is possible to pass a custom coralogix domain by using the `custom_domain` va
 | <a name="input_existing_firehose_iam"></a> [existing\_firehose\_iam](variables.tf#L185) | Use an existing IAM role to use as a firehose role. | `string` | n/a | no |
 | <a name="input_user_supplied_tags"></a> [user_supplied_tags](#input\_user_supplied_tags) | Tags supplied by the user to populate to all generated resources | `map(string)` | n/a | no |
 | <a name="input_override_default_tags"></a> [override_default_tags](#input\_override_default_tags) | Override and remove the default tags by setting to true | `bool` | `false` | no |
+| <a name="s3_enable_secure_transport"></a> [s3\_enable\_secure\_transport](variables.tf#L105) | Disable if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule | `bool` | `true` | no |
 
 ## Coralgoix regions
 

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -98,8 +98,8 @@ data "aws_iam_policy_document" "bucket_policy_doc" {
       "s3:*"
     ]
     resources = [
-      "${aws_s3_bucket.new_s3_bucket.arn}/*",
-      aws_s3_bucket.new_s3_bucket.arn
+      "${one(aws_s3_bucket.new_s3_bucket[*].arn)}/*",
+      one(aws_s3_bucket.new_s3_bucket[*].arn)
     ]
     condition {
       test     = "Bool"
@@ -111,8 +111,8 @@ data "aws_iam_policy_document" "bucket_policy_doc" {
 
 resource "aws_s3_bucket_policy" "bucket_name_policy" {
   count  = var.existing_s3_backup != null ? 0 : 1
-  bucket = aws_s3_bucket.new_s3_bucket.id
-  policy = data.aws_iam_policy_document.bucket_policy_doc.json
+  bucket = one(aws_s3_bucket.new_s3_bucket[*].id)
+  policy = one(data.aws_iam_policy_document.bucket_policy_doc[*].json)
 }
 
 ################################################################################

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -86,7 +86,7 @@ resource "aws_s3_bucket_public_access_block" "firehose_bucket_bucket_access" {
 }
 
 data "aws_iam_policy_document" "bucket_policy_doc" {
-  count  = var.existing_s3_backup != null ? 0 : 1
+  count  = var.existing_s3_backup != null ? 0 : var.s3_enable_secure_transport ? 1 : 0
   statement {
     sid    = "AllowSSLRequestsOnly"
     effect = "Deny"
@@ -110,7 +110,7 @@ data "aws_iam_policy_document" "bucket_policy_doc" {
 }
 
 resource "aws_s3_bucket_policy" "bucket_name_policy" {
-  count  = var.existing_s3_backup != null ? 0 : 1
+  count  = var.existing_s3_backup != null ? 0 : var.s3_enable_secure_transport ? 1 : 0
   bucket = one(aws_s3_bucket.new_s3_bucket[*].id)
   policy = one(data.aws_iam_policy_document.bucket_policy_doc[*].json)
 }

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -85,6 +85,28 @@ resource "aws_s3_bucket_public_access_block" "firehose_bucket_bucket_access" {
   restrict_public_buckets = true
 }
 
+data "aws_iam_policy_document" "bucket_policy_doc" {
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:*"
+    ]
+    resources = [
+      "${aws_s3_bucket.new_s3_bucket.arn}/*",
+      aws_s3_bucket.new_s3_bucket.arn
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
 ################################################################################
 # Firehose Logs Stream
 ################################################################################

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -86,6 +86,7 @@ resource "aws_s3_bucket_public_access_block" "firehose_bucket_bucket_access" {
 }
 
 data "aws_iam_policy_document" "bucket_policy_doc" {
+  count  = var.existing_s3_backup != null ? 0 : 1
   statement {
     sid    = "AllowSSLRequestsOnly"
     effect = "Deny"
@@ -106,6 +107,12 @@ data "aws_iam_policy_document" "bucket_policy_doc" {
       values   = ["false"]
     }
   }
+}
+
+resource "aws_s3_bucket_policy" "bucket_name_policy" {
+  count  = var.existing_s3_backup != null ? 0 : 1
+  bucket = aws_s3_bucket.new_s3_bucket.id
+  policy = data.aws_iam_policy_document.bucket_policy_doc.json
 }
 ################################################################################
 # Firehose Logs Stream

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -114,6 +114,7 @@ resource "aws_s3_bucket_policy" "bucket_name_policy" {
   bucket = aws_s3_bucket.new_s3_bucket.id
   policy = data.aws_iam_policy_document.bucket_policy_doc.json
 }
+
 ################################################################################
 # Firehose Logs Stream
 ################################################################################

--- a/modules/firehose-logs/variables.tf
+++ b/modules/firehose-logs/variables.tf
@@ -103,7 +103,7 @@ variable "override_default_tags" {
 }
 
 variable "s3_enable_secure_transport" {
-  description = "Enable if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule"
+  description = "Disable if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule"
   type        = bool
   default     = true
 }

--- a/modules/firehose-logs/variables.tf
+++ b/modules/firehose-logs/variables.tf
@@ -101,3 +101,9 @@ variable "override_default_tags" {
   type        = bool
   default     = false
 }
+
+variable "s3_enable_secure_transport" {
+  description = "Change to false if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule"
+  type        = bool
+  default     = true
+}

--- a/modules/firehose-logs/variables.tf
+++ b/modules/firehose-logs/variables.tf
@@ -103,7 +103,7 @@ variable "override_default_tags" {
 }
 
 variable "s3_enable_secure_transport" {
-  description = "Change to false if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule"
+  description = "Enable if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
# Description

The aws_iam_policy_document and aws_s3_bucket_policy resources were added to enforce secure access to the S3 bucket. The policy document denies any requests that do not use SSL, ensuring that all data transferred to and from the S3 bucket is encrypted in transit. This enhances the security of the data stored in the S3 bucket by preventing unencrypted access. The conditional logic ensures that the policy is only applied if a new S3 bucket is created, avoiding conflicts with existing S3 buckets.

Ref: https://repost.aws/knowledge-center/s3-bucket-policy-for-config-rule

Fixes # https://github.com/coralogix/terraform-coralogix-aws/issues/199

# How Has This Been Tested? 
Yes.

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)