### PR TITLE
Firehose outputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+  
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+          
       - name: Check for missing test directories
         run: |
           chmod +x tests/compare_directories_test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.4.1
+#### **firehose-logs**
+### 💡 Enhancements 💡
+- Added module outputs
+#### **firehose-metrics**
+### 💡 Enhancements 💡
+- Added module output `firehose_stream_arn`
+### 🧰 Bug fixes 🧰
+– Added missing docs on module outputs
+
 ## v2.4.0
 #### **firehose-logs**
 ### 💡 Enhancements 💡

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -119,5 +119,11 @@ It is possible to pass a custom coralogix domain by using the `custom_domain` va
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_firehose_stream_arn"></a> [firehose\_stream\_arn](#output\_firehose\_stream\_arn) | ARN of the Firehose Delivery Stream |
+| <a name="output_firehose_stream_name"></a> [firehose\_stream\_name](#output\_firehose\_stream\_name) | Name of the Firehose Delivery Stream |
+| <a name="output_firehose_iam_role_arn"></a> [firehose\_iam_role\_arn](#output\_firehose\_iam_role\_arn) | ARN of the Firehose IAM role |
+| <a name="output_s3_backup_bucket_arn"></a> [s3\_backup\_bucket\_arn](#output\_s3\_backup\_bucket\_arn) | ARN of the Firehose S3 Backup Bucket |
+
 <!-- END_TF_DOCS -->

--- a/modules/firehose-logs/output.tf
+++ b/modules/firehose-logs/output.tf
@@ -1,0 +1,19 @@
+output "firehose_stream_arn" {
+  value       = aws_kinesis_firehose_delivery_stream.coralogix_stream_logs.arn
+  description = "value of the firehose stream ARN"
+}
+
+output "firehose_stream_name" {
+  value       = aws_kinesis_firehose_delivery_stream.coralogix_stream_logs.name
+  description = "value of the firehose stream name"
+}
+
+output "firehose_iam_role_arn" {
+  value       = local.firehose_iam_role_arn
+  description = "value of the firehose IAM role ARN used"
+}
+
+output "s3_backup_bucket_arn" {
+  value       = local.s3_backup_bucket_arn
+  description = "value of the S3 backup bucket ARN used"
+}

--- a/modules/firehose-metrics/README.md
+++ b/modules/firehose-metrics/README.md
@@ -237,5 +237,15 @@ then the CloudWatch metric stream must be configured with the same format, confi
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_firehose_stream_arn"></a> [firehose\_stream\_arn](#output\_firehose\_stream\_arn) | ARN of the Firehose Delivery Stream |
+| <a name="output_firehose_stream_name"></a> [firehose\_stream\_name](#output\_firehose\_stream\_name) | Name of the Firehose Delivery Stream |
+| <a name="output_firehose_iam_role_arn"></a> [firehose\_iam_role\_arn](#output\_firehose\_iam_role\_arn) | ARN of the Firehose IAM role |
+| <a name="output_s3_backup_bucket_arn"></a> [s3\_backup\_bucket\_arn](#output\_s3\_backup\_bucket\_arn) | ARN of the Firehose S3 Backup Bucket |
+| <a name="output_lambda_processor_arn"></a> [lambda\_processor\_arn](#output\_lambda\_processor\_arn) | ARN of the Lambda Processor |
+| <a name="output_lambda_processor_iam_arn"></a> [lambda\_processor\_iam\_arn](#output\_lambda\_processor\_iam\_arn) | ARN of the Lambda Processor IAM role |
+| <a name="output_metric_stream_arn"></a> [metric\_stream\_arn](#output\_metric\_stream\_arn) | ARN of the CloudWatch Metric Stream |
+| <a name="output_metric_stream_iam_role_arn"></a> [metric\_stream\_iam\_role\_arn](#output\_metric\_stream\_iam\_role\_arn) | ARN of the CloudWatch Metric Stream IAM role |
+
 <!-- END_TF_DOCS -->

--- a/modules/firehose-metrics/output.tf
+++ b/modules/firehose-metrics/output.tf
@@ -1,3 +1,8 @@
+output "firehose_stream_arn" {
+  value       = aws_kinesis_firehose_delivery_stream.coralogix_stream_metrics.arn
+  description = "value of the firehose stream ARN"
+}
+
 output "firehose_stream_name" {
   value       = aws_kinesis_firehose_delivery_stream.coralogix_stream_metrics.name
   description = "value of the firehose stream name"


### PR DESCRIPTION
# Description

1. Added module outputs to `firehose-logs` which were completely missing
2. Added `firehose_stream_arn` to `firehose-metrics` module
3. Fixed the `firehose-metrics` documentation by listing all outputs available

# How Has This Been Tested?

For both modules, I've run a module instance with all changes referencing new outputs to verify they work as expected.

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)