### PR TITLE
fix: Allow user to deploy firehose-metrics module from govcloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added module output `firehose_stream_arn`
 ### 🧰 Bug fixes 🧰
 – Added missing docs on module outputs
+– Add a new variable `custom_s3_bucket` to allow users to deploy the integration in govcloud. specify a custom s3 bucket to save the lambda zip code in
 
 ## v2.4.0
 #### **firehose-logs**

--- a/modules/firehose-metrics/README.md
+++ b/modules/firehose-metrics/README.md
@@ -212,6 +212,7 @@ then the CloudWatch metric stream must be configured with the same format, confi
 | <a name="input_s3_backup_custom_name"></a> [s3\_backup\_custom\_name](variables.tf#L143) | Set the name of the S3 backup bucket, otherwise variable '{firehose_stream}-backup-metrics' will be used. | `string` | n/a | no |
 | <a name="input_existing_s3_backup"></a> [existing\_s3\_backup](variables.tf#L149) | Use an existing S3 bucket to use as a backup bucket. | `string` | n/a | no |
 | <a name="input_govcloud_deployment"></a> [govcloud\_deployment](#input\_govcloud\_deployment) | Enable if you deploy the integration in govcloud | `bool` | false | no |
+| <a name="input_custom_s3_bucket"></a> [custom\_s3\_bucket](variables.tf#L215) | The name of the s3 bucket that exists in your account to save the lambda zip code in | `string` | n/a | no |
 | <a name="input_lambda_processor_enable"></a> [lambda\_processor\_enable](variables.tf#L155) | Enable the lambda processor function. Set to false to remove the lambda and all associated resources. | `bool` | `true` | no |
 | <a name="input_lambda_processor_custom_name"></a> [lambda\_processor\_custom\_name](variables.tf#L161) | Set the name of the lambda processor function, otherwise variable '{firehose_stream}-metrics-transform' will be used | `string` | `null` | no |
 | <a name="input_lambda_processor_iam_custom_name"></a> [lambda\_processor\_iam\_custom\_name](variables.tf#L167) | Set the name of the lambda processor IAM role, otherwise variable '{firehose_stream}-lambda-processor-iam' will be used. | `string` | n/a | no |
@@ -234,6 +235,10 @@ then the CloudWatch metric stream must be configured with the same format, confi
 | `AP3` | `ap-southeast-3` | ap3.coralogix.com |
 | `US` | `us-east-2` | coralogix.us |
 | `US2` | `us-west-2` | cx498.coralogix.com |
+
+
+> [!NOTE]
+> When trying to deploy the lambda in govcloud, you will need to set the variable `govcloud_deployment` to `true` and set the variable `custom_s3_bucket` to a bucket that exists in your account, the module will upload the function source code into this bucket
 
 ## Outputs
 

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -58,10 +58,9 @@ resource "null_resource" "s3_bucket_copy" {
 
   provisioner "local-exec" {
     command = <<-EOF
-      file_name="bootstrap.zip"
-      curl -o $file_name https://cx-cw-metrics-tags-lambda-processor-eu-west-1.s3.eu-west-1.amazonaws.com/bootstrap.zip
+      curl -o bootstrap.zip https://cx-cw-metrics-tags-lambda-processor-eu-west-1.s3.eu-west-1.amazonaws.com/bootstrap.zip
       aws s3 cp --region ${data.aws_region.current_region.name} ./bootstrap.zip s3://${var.custom_s3_bucket}
-      rm ./$file_name
+      rm ./bootstrap.zip
     EOF
   }
 }
@@ -296,7 +295,7 @@ resource "aws_cloudwatch_log_group" "loggroup" {
 }
 
 resource "aws_lambda_function" "lambda_processor" {
-  # depends_on = [null_resource.s3_bucket_copy]
+  depends_on    = [null_resource.s3_bucket_copy]
   count         = var.lambda_processor_enable ? 1 : 0
   s3_bucket     = var.custom_s3_bucket != null ? var.custom_s3_bucket : "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.name}"
   s3_key        = "bootstrap.zip"

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -297,7 +297,7 @@ resource "aws_cloudwatch_log_group" "loggroup" {
 resource "aws_lambda_function" "lambda_processor" {
   depends_on    = [null_resource.s3_bucket_copy]
   count         = var.lambda_processor_enable ? 1 : 0
-  s3_bucket     = var.custom_s3_bucket != null ? var.custom_s3_bucket : "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.name}"
+  s3_bucket     = coalesce(var.custom_s3_bucket, "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.name}")
   s3_key        = "bootstrap.zip"
   function_name = local.lambda_processor_name
   role          = local.lambda_processor_iam_role_arn

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -53,6 +53,19 @@ resource "random_string" "this" {
   upper   = false
 }
 
+resource "null_resource" "s3_bucket_copy" {
+  count = var.custom_s3_bucket != null ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOF
+      file_name="bootstrap.zip"
+      curl -o $file_name https://cx-cw-metrics-tags-lambda-processor-eu-west-1.s3.eu-west-1.amazonaws.com/bootstrap.zip
+      aws s3 cp --region ${data.aws_region.current_region.name} ./bootstrap.zip s3://${var.custom_s3_bucket}
+      rm ./$file_name
+    EOF
+  }
+}
+
 ################################################################################
 # Firehose Delivery Stream
 ################################################################################
@@ -283,8 +296,9 @@ resource "aws_cloudwatch_log_group" "loggroup" {
 }
 
 resource "aws_lambda_function" "lambda_processor" {
+  # depends_on = [null_resource.s3_bucket_copy]
   count         = var.lambda_processor_enable ? 1 : 0
-  s3_bucket     = "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.name}"
+  s3_bucket     = var.custom_s3_bucket != null ? var.custom_s3_bucket : "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.name}"
   s3_key        = "bootstrap.zip"
   function_name = local.lambda_processor_name
   role          = local.lambda_processor_iam_role_arn

--- a/modules/firehose-metrics/variables.tf
+++ b/modules/firehose-metrics/variables.tf
@@ -218,3 +218,8 @@ variable "override_default_tags" {
   default     = false
 }
 
+variable "custom_s3_bucket" {
+  description = "Custom S3 bucket to use for the lambda processor"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
# Description
Add new variable `custom_s3_bucket`, to allow to deploy the module in govcloud.
We don't have a bucket with source code to the lambda function in gov cloud, so in case a customer tries to deploy the integration there, he will get an error, with this variable, the module will download the lambda source code to an S3 bucket in his env so the lambda will have access to it.
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #202 

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)