### PR TITLE
feat: Add option to filter events by detail_type in eventbridge module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.7.0
+#### **eventbridge**
+### 🚀 New components 🚀
+- Add support to filter events by detail type
+
 ## v2.6.1
 #### **coralogix-aws-shipper**
 ### 🧰 Bug fixes 🧰

--- a/examples/eventbridge/variables.tf
+++ b/examples/eventbridge/variables.tf
@@ -15,7 +15,18 @@ variable "private_key" {
 }
 
 variable "coralogix_region" {
-  description = "Coralogix account region: us, singapore, ireland, india, stockholm [in lower-case letters]"
+  description = "The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, AP3, US1, US2]"
+  type        = string
+  validation {
+    condition     = contains(["EU1", "EU2", "AP1", "AP2", "AP3", "US1", "US2", "ireland", "india", "stockholm", "singapore", "us", "us2", "Custom"], var.coralogix_region)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, AP1, AP2, AP3, US1, US2, Custom]."
+  }
+}
+
+variable "custom_url" {
+  description = "Custom coralogix url"
+  type        = string
+  default     = ""
 }
 
 variable "sources" {
@@ -27,5 +38,16 @@ variable "sources" {
 variable "application_name" {
   description = "Coralogix application name"
   type        = string
+  default     = null
+}
+variable "policy_name" {
+  description = "AWS IAM policy name"
+  type        = string
+  default     = "EventBridge_policy"
+}
+
+variable "detail_type" {
+  description = "AWS eventbridge detail type"
+  type        = list(string)
   default     = null
 }

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -21,12 +21,14 @@ The application name by default is the eventbridge delivery stream name, but it 
 
 ### Coralogix account region
 The coralogix region variable accepts one of the following regions:
-* us
-* singapore
-* ireland
-* india
-* stockholm
-* custom
+* EU1
+* EU2
+* AP1
+* AP2
+* AP3
+* US1
+* US2
+* Custom
 
 *** All of the regions must be written with lower-case letters. 
 
@@ -34,12 +36,14 @@ The coralogix region variable accepts one of the following regions:
 
 | Region    | Logs Endpoint
 |-----------|-----------------------------------------------------------------|
-| us        | `https://aws-events.coralogix.us/aws/event`                |
-| us2       | `https://aws-events.cx498.coralogix.com/aws/event`         |
-| singapore | `https://aws-events.coralogixsg.com/aws/event`             |
-| ireland   | `https://aws-events.coralogix.com/aws/event`               |
-| india     | `https://aws-events.coralogix.in/aws/event`            |
-| stockholm | `https://aws-events.eu2.coralogix.com/aws/event` |
+| EU1       | `https://aws-events.coralogix.us/aws/event`                |
+| EU2       | `https://aws-events.eu2.coralogix.com/aws/event`           |
+| AP1       | `https://aws-events.coralogixsg.com/aws/event`             |
+| AP2       | `https://aws-events.coralogixsg.com/aws/event`             |
+| AP3       | `https://aws-events.ap3.coralogix.com/aws/event`           |
+| US1       | `https://aws-events.coralogix.us/aws/event`                |
+| US2       | `https://aws-events.cx498.coralogix.us/aws/event`          |
+| Custom    | `https://aws-events.<custom_domain>/aws/event`             |
 
 
 ## Requirements
@@ -80,16 +84,7 @@ The coralogix region variable accepts one of the following regions:
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | The name of the eventbridge role | `string` | n/a | yes |
 | <a name="input_sources"></a> [sources](#input\_sources) | The services for which we will send events | `list(any)` | <pre>[<br>  "aws.ec2",<br>  "aws.autoscaling",<br>  "aws.cloudwatch",<br>  "aws.events",<br>  "aws.health",<br>  "aws.rds"<br>]</pre> | no |
 | <a name="input_policy_name"></a> [policy_name](#input\_custom\_url) | Custom aws_iam_policy | `string` | `EventBridge_policy` | no |
-
-## Coralgoix regions
-| Coralogix region | AWS Region | Coralogix Domain |
-|------|------------|------------|
-| `Ireland` |  `eu-west-1` | coralogix.com |
-| `Stockholm` | `eu-north-1` | eu2.coralogix.com |
-| `India` | `ap-south-1`  | coralogix.in |
-| `Singapore` | `ap-southeast-1` | coralogixsg.com |
-| `US` | `us-east-2` | coralogix.us |
-| `US2` | `us-west-2` | cx498.coralogix.com |
+| <a name="input_detail_type"></a> [detail_type](#input\_detail\_type) | AWS eventbridge detail type for the rule to filter by | `list(string)` | `null` | no |
 
 ## Outputs
 

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -15,7 +15,12 @@ variable "private_key" {
 }
 
 variable "coralogix_region" {
-  description = "Coralogix account region: us, us2, singapore, ireland, india, stockholm, custom [in lower-case letters]"
+  description = "The Coralogix location region, possible options are [EU1, EU2, AP1, AP2, AP3, US1, US2]"
+  type        = string
+  validation {
+    condition     = contains(["EU1", "EU2", "AP1", "AP2", "AP3", "US1", "US2", "ireland", "india", "stockholm", "singapore", "us", "us2", "Custom"], var.coralogix_region)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, AP1, AP2, AP3, US1, US2, Custom]."
+  }
 }
 
 variable "custom_url" {
@@ -39,4 +44,10 @@ variable "policy_name" {
   description = "AWS IAM policy name"
   type        = string
   default     = "EventBridge_policy"
+}
+
+variable "detail_type" {
+  description = "AWS eventbridge detail type"
+  type        = list(string)
+  default     = null
 }

--- a/modules/locals_variables/locals.tf
+++ b/modules/locals_variables/locals.tf
@@ -14,15 +14,21 @@ locals {
   coralogix_domains = {
     Europe    = "coralogix.com"
     EU1       = "coralogix.com"
+    ireland   = "coralogix.com"
     Europe2   = "eu2.coralogix.com"
+    stockholm = "eu2.coralogix.com"
     EU2       = "eu2.coralogix.com"
     India     = "coralogix.in"
+    india     = "coralogix.in"
     AP1       = "coralogix.in"
     Singapore = "coralogixsg.com"
+    singapore = "coralogixsg.com"
     AP2       = "coralogixsg.com"
     US        = "coralogix.us"
+    us        = "coralogix.us"
     US1       = "coralogix.us"
     US2       = "cx498.coralogix.com"
+    us2       = "cx498.coralogix.com"
     AP3       = "ap3.coralogix.com"
   }
 


### PR DESCRIPTION
# Description
- Update the coralogix region to also support the new regions
- Add option to filter in the event rule by `detail_type` and not only by source
- Fixed an issue that the event rule that get create always attaches to the Default event bus, so it will now get attached to the one that is provided in `eventbridge_stream` variable
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)