### PR TITLE
[FEAT] Add support to handle multiple S3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 ### 🚀 New components 🚀
 - Add KMS Key support for S3 Buckets
 
+## v3.1.0
+#### **coralogix-aws-shipper**
+### 💡 Enhancements 💡
+- Add support to deploy the integration with multiple S3 buckets
+
 ## v2.7.0
 #### **eventbridge**
 ### 🚀 New components 🚀

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -59,7 +59,7 @@ If you're deploying multiple integrations through the same S3 bucket, you'll nee
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | The name of the S3 bucket to watch. | `string` | n/a | yes |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Comma separated list of the names for the S3 bucket to watch. | `string` | n/a | yes |
 | <a name="input_s3_key_prefix"></a> [s3\_key\_prefix](#input\_s3\_key\_prefix) | The S3 path prefix to watch. | `string` |  n/a | no |
 | <a name="input_s3_key_suffix"></a> [s3\_key\_suffix](#input\_s3\_key\_suffix) | The S3 path suffix to watch. | `string` |  n/a | no |
 | <a name="input_s3_bucket_kms_arn"></a> [s3\_bucket\_kms\_arn](#input\_s3\_bucket\_kms\_arn) | The AWS ARN of the KMS key used to encrypt/decrypt objects in the specified S3 bucket. If provided, the Lambda policy will include permissions to decrypt using this key. | `string` |  n/a | no |

--- a/modules/coralogix-aws-shipper/S3.tf
+++ b/modules/coralogix-aws-shipper/S3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket_notification" "lambda_notification" {
-  for_each   = local.s3_bucket_names != [] && local.sns_enable != true && var.sqs_name == null && var.telemetry_mode != "metrics" ? data.aws_s3_bucket.this : {}
+  for_each   = local.s3_bucket_names != toset([]) && local.sns_enable != true && var.sqs_name == null && var.telemetry_mode != "metrics" ? data.aws_s3_bucket.this : {}
   depends_on = [module.lambda]
   bucket     = each.value.bucket
   dynamic "lambda_function" {
@@ -8,8 +8,8 @@ resource "aws_s3_bucket_notification" "lambda_notification" {
     content {
       lambda_function_arn = module.lambda[integration_info.key].lambda_function_arn
       events              = ["s3:ObjectCreated:*"]
-      filter_prefix       = integration_info.value.s3_key_prefix != null || (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") && integration_info.value.s3_bucket_name == each.key ? integration_info.value.s3_key_prefix : "AWSLogs/"
-      filter_suffix       = (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") || integration_info.value.s3_key_suffix != null && integration_info.value.s3_bucket_name == each.key ? integration_info.value.s3_key_suffix : lookup(local.s3_suffix_map, integration_info.value.integration_type)
+      filter_prefix       = integration_info.value.s3_key_prefix != null || (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") ? integration_info.value.s3_key_prefix : "AWSLogs/"
+      filter_suffix       = (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") || integration_info.value.s3_key_suffix != null ? integration_info.value.s3_key_suffix : lookup(local.s3_suffix_map, integration_info.value.integration_type)
     }
   }
 }

--- a/modules/coralogix-aws-shipper/S3.tf
+++ b/modules/coralogix-aws-shipper/S3.tf
@@ -1,15 +1,15 @@
 resource "aws_s3_bucket_notification" "lambda_notification" {
-  count      = var.s3_bucket_name != null && local.sns_enable != true && var.sqs_name == null && var.telemetry_mode != "metrics" ? 1 : 0
+  for_each   = local.s3_bucket_names != [] && local.sns_enable != true && var.sqs_name == null && var.telemetry_mode != "metrics" ? data.aws_s3_bucket.this : {}
   depends_on = [module.lambda]
-  bucket     = data.aws_s3_bucket.this[0].bucket
+  bucket     = each.value.bucket
   dynamic "lambda_function" {
-    for_each = var.integration_info != null ? var.integration_info : local.integration_info
+    for_each = local.integration_info
     iterator = integration_info
     content {
       lambda_function_arn = module.lambda[integration_info.key].lambda_function_arn
       events              = ["s3:ObjectCreated:*"]
-      filter_prefix       = integration_info.value.s3_key_prefix != null || (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") ? integration_info.value.s3_key_prefix : "AWSLogs/"
-      filter_suffix       = (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") || integration_info.value.s3_key_suffix != null ? integration_info.value.s3_key_suffix : lookup(local.s3_suffix_map, integration_info.value.integration_type)
+      filter_prefix       = integration_info.value.s3_key_prefix != null || (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") && integration_info.value.s3_bucket_name == each.key ? integration_info.value.s3_key_prefix : "AWSLogs/"
+      filter_suffix       = (integration_info.value.integration_type != "CloudTrail" && integration_info.value.integration_type != "VpcFlow") || integration_info.value.s3_key_suffix != null && integration_info.value.s3_bucket_name == each.key ? integration_info.value.s3_key_suffix : lookup(local.s3_suffix_map, integration_info.value.integration_type)
     }
   }
 }

--- a/modules/coralogix-aws-shipper/Sns.tf
+++ b/modules/coralogix-aws-shipper/Sns.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket_notification" "topic_notification" {
   depends_on = [module.lambda]
   count      = local.sns_enable == true && (var.integration_type == "S3" || var.integration_type == "CloudTrail") ? 1 : 0
-  bucket     = data.aws_s3_bucket.this[0].bucket
+  bucket     = one(values(data.aws_s3_bucket.this)).bucket
   topic {
     topic_arn     = data.aws_sns_topic.sns_topic[0].arn
     events        = ["s3:ObjectCreated:*"]

--- a/modules/coralogix-aws-shipper/Sqs.tf
+++ b/modules/coralogix-aws-shipper/Sqs.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_bucket_notification" "sqs_notification" {
   depends_on = [module.lambda]
   count      = var.sqs_name != null && (var.integration_type == "S3" || var.integration_type == "CloudTrail") ? 1 : 0
-  bucket     = data.aws_s3_bucket.this[0].bucket
+  bucket     = one(values(data.aws_s3_bucket.this)).bucket
   queue {
     queue_arn     = data.aws_sqs_queue.name[0].arn
     events        = ["s3:ObjectCreated:*"]

--- a/modules/coralogix-aws-shipper/data.tf
+++ b/modules/coralogix-aws-shipper/data.tf
@@ -13,8 +13,8 @@ data "aws_cloudwatch_log_group" "this" {
 }
 
 data "aws_s3_bucket" "this" {
-  count  = var.s3_bucket_name == null ? 0 : 1
-  bucket = var.s3_bucket_name
+  for_each = local.s3_bucket_names
+  bucket   = each.value
 }
 
 data "aws_s3_bucket" "dlq_bucket" {

--- a/modules/coralogix-aws-shipper/data.tf
+++ b/modules/coralogix-aws-shipper/data.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "topic" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = [data.aws_s3_bucket.this[0].arn]
+      values   = [one(values(data.aws_s3_bucket.this)).arn]
     }
   }
 }

--- a/modules/coralogix-aws-shipper/firehose.tf
+++ b/modules/coralogix-aws-shipper/firehose.tf
@@ -9,7 +9,7 @@ resource "aws_iam_role_policy" "s3_firehose_metrics_policy" {
       {
         Effect   = "Allow"
         Action   = ["s3:AbortMultipartUpload", "s3:GetBucketLocation", "s3:GetObject", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:PutObject"]
-        Resource = ["${local.arn_prefix}:s3:::${var.s3_bucket_name}", "${local.arn_prefix}:s3:::${var.s3_bucket_name}/*"]
+        Resource = flatten([for bucket in local.s3_bucket_names : ["${local.arn_prefix}:s3:::${bucket}", "${local.arn_prefix}:s3:::${bucket}/*"]])
       },
       {
         Effect   = "Allow"

--- a/modules/coralogix-aws-shipper/firehose.tf
+++ b/modules/coralogix-aws-shipper/firehose.tf
@@ -126,14 +126,14 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
   extended_s3_configuration {
     s3_backup_mode     = "Enabled"
     role_arn           = aws_iam_role.s3_firehose_metrics_role[0].arn
-    bucket_arn         = data.aws_s3_bucket.this[0].arn
+    bucket_arn         = one(values(data.aws_s3_bucket.this)).arn
     compression_format = "GZIP"
     prefix             = "coralogix-aws-shipper-metrics"
     buffering_size     = 5
     buffering_interval = 60
 
     s3_backup_configuration {
-      bucket_arn         = data.aws_s3_bucket.this[0].arn
+      bucket_arn         = one(values(data.aws_s3_bucket.this)).arn
       role_arn           = aws_iam_role.s3_firehose_metrics_role[0].arn
       buffering_size     = 5
       buffering_interval = 60

--- a/modules/coralogix-aws-shipper/local.tf
+++ b/modules/coralogix-aws-shipper/local.tf
@@ -19,8 +19,9 @@ locals {
 
   api_key_is_arn = replace(nonsensitive(var.api_key), ":", "") != nonsensitive(var.api_key) ? true : false
 
-  integration_info = var.integration_info == null ? {
+  sensitive_integration_info = var.integration_info == null ? {
     integration = {
+      bucket_name                      = local.s3_bucket_names[0]
       application_name                 = var.application_name
       subsystem_name                   = var.subsystem_name
       integration_type                 = var.integration_type
@@ -33,11 +34,28 @@ locals {
       api_key                          = var.api_key
       store_api_key_in_secrets_manager = var.store_api_key_in_secrets_manager
     }
-  } : {}
+    } : var.api_key == "" ? var.integration_info : {
+    for k, v in var.integration_info : k => {
+      s3_bucket_name                   = v.s3_bucket_name
+      s3_key_prefix                    = v.s3_key_prefix
+      s3_key_suffix                    = v.s3_key_suffix
+      application_name                 = v.application_name
+      subsystem_name                   = v.subsystem_name
+      integration_type                 = v.integration_type
+      lambda_name                      = v.lambda_name
+      newline_pattern                  = v.newline_pattern
+      blocking_pattern                 = v.blocking_pattern
+      lambda_log_retention             = v.lambda_log_retention
+      api_key                          = v.api_key != null ? v.api_key : var.api_key
+      store_api_key_in_secrets_manager = v.store_api_key_in_secrets_manager
+    }
+  }
+  integration_info = try(nonsensitive(local.sensitive_integration_info), local.sensitive_integration_info)
 
   is_s3_integration  = var.integration_type == "S3Csv" || var.integration_type == "CloudFront" || var.integration_type == "S3" || var.integration_type == "CloudTrail" || var.integration_type == "VpcFlow" ? true : false
   is_sns_integration = local.sns_enable && (var.integration_type == "S3" || var.integration_type == "Sns" || var.integration_type == "CloudTrail") ? true : false
   is_sqs_integration = var.sqs_name != null && (var.integration_type == "S3" || var.integration_type == "CloudTrail" || var.integration_type == "Sqs") ? true : false
 
-  arn_prefix = "arn:${data.aws_partition.current.partition}"
+  arn_prefix      = "arn:${data.aws_partition.current.partition}"
+  s3_bucket_names = var.s3_bucket_name != null ? toset(split(",", var.s3_bucket_name)) : toset([])
 }

--- a/modules/coralogix-aws-shipper/local.tf
+++ b/modules/coralogix-aws-shipper/local.tf
@@ -21,7 +21,7 @@ locals {
 
   sensitive_integration_info = var.integration_info == null ? {
     integration = {
-      bucket_name                      = local.s3_bucket_names[0]
+      s3_bucket_name                   = var.s3_bucket_name
       application_name                 = var.application_name
       subsystem_name                   = var.subsystem_name
       integration_type                 = var.integration_type

--- a/modules/coralogix-aws-shipper/main.tf
+++ b/modules/coralogix-aws-shipper/main.tf
@@ -88,12 +88,12 @@ resource "aws_iam_policy" "lambda_policy" {
           Resource = ["*"]
         },
 
-        # SQS S3 Integration Policy
-        {
-          Effect   = "Allow",
-          Action   = var.sqs_name != null && var.s3_bucket_name != null ? ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation", "s3:GetObjectVersion", "s3:GetLifecycleConfiguration"] : ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-          Resource = var.sqs_name != null && var.s3_bucket_name != null ? ["${data.aws_s3_bucket.this[0].arn}/*", data.aws_s3_bucket.this[0].arn] : ["*"]
-        },
+      # SQS S3 Integration Policy
+      {
+        Effect   = "Allow",
+        Action   = var.sqs_name != null && local.s3_bucket_names != [] ? ["s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation", "s3:GetObjectVersion", "s3:GetLifecycleConfiguration"] : ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        Resource = var.sqs_name != null && local.s3_bucket_names != [] ? flatten([for bucket in data.aws_s3_bucket.this : ["${bucket.arn}/*", "${bucket.arn}"]]) : ["*"]
+      },
 
         # EcrScan Integration Policy
         {
@@ -102,19 +102,19 @@ resource "aws_iam_policy" "lambda_policy" {
           Resource = ["*"]
         },
 
-        # S3 Integration Policy
-        {
-          Effect   = "Allow",
-          Action   = var.s3_bucket_name != null && var.sqs_name == null ? ["s3:GetObject"] : ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-          Resource = var.s3_bucket_name != null && var.sqs_name == null ? ["${data.aws_s3_bucket.this[0].arn}/*"] : ["*"]
-        },
+      # S3 Integration Policy
+      {
+        Effect   = "Allow",
+        Action   = local.s3_bucket_names != [] && var.sqs_name == null ? ["s3:GetObject"] : ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        Resource = local.s3_bucket_names != [] && var.sqs_name == null ? flatten([for bucket in data.aws_s3_bucket.this : ["${bucket.arn}/*", "${bucket.arn}"]]) : ["*"]
+      },
 
-        #S3 with SQS Integration Policy
-        {
-          Effect   = "Allow",
-          Action   = var.s3_bucket_name != null && var.sqs_name != null ? ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"] : ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
-          Resource = var.s3_bucket_name != null && var.sqs_name != null ? [data.aws_sqs_queue.name[0].arn] : ["*"]
-        },
+      #S3 with SQS Integration Policy
+      {
+        Effect   = "Allow",
+        Action   = local.s3_bucket_names != [] && var.sqs_name != null ? ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"] : ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        Resource = local.s3_bucket_names != [] && var.sqs_name != null ? [data.aws_sqs_queue.name[0].arn] : ["*"]
+      },
 
         # Kinesis Integration policy
         {
@@ -227,10 +227,10 @@ module "lambda" {
   attach_policy_statements                = false
   create_role                             = false
   lambda_role                             = var.execution_role_name != null ? data.aws_iam_role.LambdaExecutionRole[0].arn : aws_iam_role.lambda_role[0].arn
-  allowed_triggers = var.s3_bucket_name != null && local.sns_enable != true ? {
-    AllowExecutionFromS3 = {
+  allowed_triggers = local.s3_bucket_names != [] && local.sns_enable != true ? {
+    for bucket in data.aws_s3_bucket.this : "AllowExecutionFromS3_${bucket.bucket}" => {
       principal  = "s3.amazonaws.com"
-      source_arn = data.aws_s3_bucket.this[0].arn
+      source_arn = bucket.arn
     }
     } : var.msk_cluster_arn != null ? {
     AllowExecutionFromMSK = {
@@ -305,7 +305,7 @@ resource "aws_secretsmanager_secret" "coralogix_secret" {
 
 resource "aws_secretsmanager_secret_version" "service_user" {
   for_each = {
-    for key, integration_info in var.integration_info != null ? var.integration_info : local.integration_info : key => integration_info
+    for key, integration_info in local.integration_info : key => integration_info
     if !local.api_key_is_arn && (integration_info.store_api_key_in_secrets_manager == null || integration_info.store_api_key_in_secrets_manager == true)
   }
   depends_on    = [aws_secretsmanager_secret.coralogix_secret]

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -54,7 +54,7 @@ variable "sampling_rate" {
 }
 
 variable "s3_bucket_name" {
-  description = "The name of the S3 bucket to watch"
+  description = "The name of the S3 bucket to watch, this accepts also a comma separated list of bucket names."
   type        = string
   default     = null
 }
@@ -92,6 +92,7 @@ variable "custom_csv_header" {
 variable "integration_info" {
   description = "Values of s3 integraion in case that you want to deploy more than one integration"
   type = map(object({
+    s3_bucket_name                   = optional(string)
     s3_key_prefix                    = optional(string)
     s3_key_suffix                    = optional(string)
     application_name                 = string
@@ -101,7 +102,7 @@ variable "integration_info" {
     newline_pattern                  = optional(string)
     blocking_pattern                 = optional(string)
     lambda_log_retention             = optional(number)
-    api_key                          = string
+    api_key                          = optional(string)
     store_api_key_in_secrets_manager = optional(bool)
   }))
   default = null


### PR DESCRIPTION
# Description

This pull request introduces several changes to the `coralogix-aws-shipper` module to support multiple S3 bucket integrations. The most important changes include updating the handling of S3 bucket names, modifying IAM policies, and adjusting local variables to accommodate multiple S3 buckets.

### Support for Multiple S3 Buckets:

* [`modules/coralogix-aws-shipper/README.md`](diffhunk://#diff-4b8fab99ae82e26c1de360f5a5ceb22dee83abefe93435feaba8b6c360935ff2L60-R60): Updated the description of the `s3_bucket_name` input to indicate that it now accepts a comma-separated list of bucket names.
* [`modules/coralogix-aws-shipper/variables.tf`](diffhunk://#diff-3c20c8478f6f4c2608c145801608fe897f66820fc3062ac0c03e0422f943f786L57-R57): Modified the `s3_bucket_name` variable to accept a comma-separated list of bucket names and updated the `integration_info` object to include an optional `s3_bucket_name` field. [[1]](diffhunk://#diff-3c20c8478f6f4c2608c145801608fe897f66820fc3062ac0c03e0422f943f786L57-R57) [[2]](diffhunk://#diff-3c20c8478f6f4c2608c145801608fe897f66820fc3062ac0c03e0422f943f786R89) [[3]](diffhunk://#diff-3c20c8478f6f4c2608c145801608fe897f66820fc3062ac0c03e0422f943f786L98-R99)

### Changes to Resource Definitions:

* [`modules/coralogix-aws-shipper/S3.tf`](diffhunk://#diff-1818f2640c9b9eb0b7db4e7e56a066d02ec2f8f0e7d7c49e80ce6f0e66fc3d8aL2-R12): Replaced the `count` attribute with `for_each` for `aws_s3_bucket_notification` to handle multiple S3 buckets.
* [`modules/coralogix-aws-shipper/data.tf`](diffhunk://#diff-db8978ebc2038db7c129e718f49d985558cf32049138668658b302e6616ded65L16-R17): Updated the `aws_s3_bucket` data source to use `for_each` instead of `count` for multiple S3 buckets.

### IAM Policy Adjustments:

* [`modules/coralogix-aws-shipper/firehose.tf`](diffhunk://#diff-2bcc83b513161773c641ab9a3163f16729833ba1fe6a3da16c5b0edd673ae9a5L12-R12): Modified the `aws_iam_role_policy` resource to handle multiple S3 buckets by using the `flatten` function.
* [`modules/coralogix-aws-shipper/main.tf`](diffhunk://#diff-904f99df742de05742ba5848103187d77ffcedbad597cc1ca84529ffb2f1c1d7L93-R94): Updated IAM policies to use `flatten` and `for` loops for handling multiple S3 buckets in various integration scenarios. [[1]](diffhunk://#diff-904f99df742de05742ba5848103187d77ffcedbad597cc1ca84529ffb2f1c1d7L93-R94) [[2]](diffhunk://#diff-904f99df742de05742ba5848103187d77ffcedbad597cc1ca84529ffb2f1c1d7L107-R115) [[3]](diffhunk://#diff-904f99df742de05742ba5848103187d77ffcedbad597cc1ca84529ffb2f1c1d7L221-R224) [[4]](diffhunk://#diff-904f99df742de05742ba5848103187d77ffcedbad597cc1ca84529ffb2f1c1d7L299-R299)

### Local Variables Adjustments:

* [`modules/coralogix-aws-shipper/local.tf`](diffhunk://#diff-530acc73d5ee78d571e148e8dfa03d0235ba26d5fe868a645b89d5f027eec9cfL22-R24): Introduced `sensitive_integration_info` and updated `integration_info` to handle multiple S3 buckets. Added a new local variable `s3_bucket_names` to split the comma-separated list of bucket names. [[1]](diffhunk://#diff-530acc73d5ee78d571e148e8dfa03d0235ba26d5fe868a645b89d5f027eec9cfL22-R24) [[2]](diffhunk://#diff-530acc73d5ee78d571e148e8dfa03d0235ba26d5fe868a645b89d5f027eec9cfL36-R60)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [] This change does not affect module (e.g. it's readme file change)