### PR TITLE
feat: add multi-account and multi-region support for resource-metadata-sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.4.0
+#### **resource-metadata-sqs**
+### 💡 Enhancements 💡
+- Add support for multi-region and cross-account metadata collection
+
 ## v3.3.0
 #### **ecs-ec2**
 ### 💡 Enhancements 💡

--- a/modules/resource-metadata-sqs/main.tf
+++ b/modules/resource-metadata-sqs/main.tf
@@ -90,6 +90,8 @@ module "collector_lambda" {
     IS_EC2_RESOURCE_TYPE_EXCLUDED        = var.excluded_ec2_resource_type
     IS_LAMBDA_RESOURCE_TYPE_EXCLUDED     = var.excluded_lambda_resource_type
     METADATA_QUEUE_URL                   = aws_sqs_queue.metadata_queue.url
+    REGIONS                              = length(var.source_regions) > 0 ? join(",", var.source_regions) : null
+    CROSSACCOUNT_IAM_ROLE_ARNS           = length(var.cross_account_iam_role_arns) > 0 ? join(",", var.cross_account_iam_role_arns) : null
   }
 
   s3_existing_package = {
@@ -127,6 +129,13 @@ module "collector_lambda" {
       ]
       resources = [aws_sqs_queue.metadata_queue.arn]
     }
+    assume_role = length(var.cross_account_iam_role_arns) > 0 ? {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole"
+      ]
+      resources = var.cross_account_iam_role_arns
+    } : null
   }
 
   allowed_triggers = {
@@ -192,6 +201,13 @@ module "generator_lambda" {
       ]
       resources = [aws_sqs_queue.metadata_queue.arn]
     }
+    assume_role = length(var.cross_account_iam_role_arns) > 0 ? {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole"
+      ]
+      resources = var.cross_account_iam_role_arns
+    } : null
   }
 
   allowed_triggers = {
@@ -270,6 +286,13 @@ module "generator_lambda_sm" {
       ]
       resources = [aws_sqs_queue.metadata_queue.arn]
     }
+    assume_role = length(var.cross_account_iam_role_arns) > 0 ? {
+      effect = "Allow"
+      actions = [
+        "sts:AssumeRole"
+      ]
+      resources = var.cross_account_iam_role_arns
+    } : null
     secrets = {
       effect = "Allow"
       actions = [

--- a/modules/resource-metadata-sqs/variables.tf
+++ b/modules/resource-metadata-sqs/variables.tf
@@ -30,6 +30,18 @@ variable "event_mode" {
   default = "Disabled"
 }
 
+variable "source_regions" {
+  description = "The regions to collect metadata from, separated by commas (e.g. eu-north-1,eu-west-1,us-east-1). Leave empty if you want to collect metadata from the current region only."
+  type        = list(string)
+  default     = []
+}
+
+variable "cross_account_iam_role_arns" {
+  description = "The IAM role ARNs to collect metadata from, separated by commas (e.g. arn:aws:iam::123456789012:role/CrossAccountRole,arn:aws:iam::123456789012:role/AnotherCrossAccountRole). Leave empty if you want to collect metadata from the current account only."
+  type        = list(string)
+  default     = []
+}
+
 variable "secret_manager_enabled" {
   description = "Set to true in case that you want to keep your Coralogix Send Your Data API Key as a secret in aws Secret Manager"
   type        = bool

--- a/tests/resource-metadata-sqs/resource-metadata-sqs.tf
+++ b/tests/resource-metadata-sqs/resource-metadata-sqs.tf
@@ -34,3 +34,12 @@ module "resource-metadata-sqs-event-mode-existing-trail" {
   api_key          = "{{ secrets.TESTING_PRIVATE_KEY }}"
   event_mode       = "EnabledWithExistingTrail"
 }
+
+module "resource-metadata-sqs-multi-region-cross-account" {
+  source = "../../modules/resource-metadata-sqs"
+
+  coralogix_region            = "EU1"
+  api_key                     = "{{ secrets.TESTING_PRIVATE_KEY }}"
+  source_regions              = ["eu-north-1", "eu-west-1", "us-east-1"]
+  cross_account_iam_role_arns = ["arn:aws:iam::123456789012:role/CrossAccountRole"]
+}


### PR DESCRIPTION
# Description

Fixes CDS-1996, updating the tf module along with the new version of `resource-metadata-sqs`, see https://github.com/coralogix/coralogix-aws-serverless/pull/172 for more details on features.

# How Has This Been Tested?

run tf plan/tf apply on the new module version

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)