### PR TITLE
fix: Add missing permission to lambda function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## v3.4.2
+#### **lambda-manager**
+### 🧰 Bug fixes 🧰
+- Add missing permissions to lambda function
+### 💡 Enhancements 💡
+- Add support for log_group_permissions_prefix variable
+
 ## v3.4.1
 #### **firehose-logs**
 ###  💡 Configuration update 💡

--- a/modules/lambda-manager/README.md
+++ b/modules/lambda-manager/README.md
@@ -25,10 +25,11 @@ This Lambda Function was created to pick up newly created and existing log group
 ## Environment variables:
 
 | Parameter | Description | Default Value | Required |
-|---|---|---|---|
+|-----------|-------------|---------------|----------|
 | regex_pattern | Set up this regex to match the Log Groups names that you want to automatically subscribe to the destination| | yes |
 | logs_filter | Subscription filter to select which logs needs to be sent to Coralogix. For Example for Lambda Errors that are not sendable by Coralogix Lambda Layer '?REPORT ?"Task timed out" ?"Process exited before completing" ?errorMessage ?"module initialization error:" ?"Unable to import module" ?"ERROR Invoke Error" ?"EPSAGON_TRACE:"'. | | yes |
-| destination_arn | Arn for the firehose to subscribe the log groups (By default is the firehose created by Serverless Template) | | yes |
+| log_group_permissions_prefix | A list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the regex_pattern parameter.  For more information, refer to the Note below.| | no |
+| destination_arn | Arn for the firehose to subscribe the log groups (By default, is the firehose created by Serverless Template) | | yes |
 | destination_role | Arn for the role to allow destination subscription to be pushed (In case you use Firehose) | n/a | no |
 | destination_type | Type of destination (Lambda or Firehose) | | yes |
 | scan_old_loggroups | This will scan all LogGroups in the account and apply the subscription configured, will only run Once and set to false. Default is false | false | yes |
@@ -36,6 +37,11 @@ This Lambda Function was created to pick up newly created and existing log group
 | memory_size | The maximum allocated memory this lambda may consume. Default value is the minimum recommended setting please consult coralogix support before changing. | 1024 |  |
 | timeout | The maximum time in seconds the function may be allowed to run. Default value is the minimum recommended setting please consult coralogix support before changing. | 300 |  |
 | notification_email | Failure notification email address | | |
+
+> [!Note]
+> In case the destination is lambda, then the code will add log groups that match the regex_pattern and then add them to the destination Lambda as triggers, each log group will also add permission to the Lambda, in some cases when there are a lot of log groups this will cause an error because the code tries to create too many permissions for the Lambda (AWS have a limitation for the number of permission that you can have for a Lambda), and this is why we have the `log_group_permissions_prefix` parameter, this parameter will add only permission to the Lambda 
+> using a wildcard( * ).for example, in case I have the log groups: log1,log2,log3 instead that the code will create for each of the log group permission to trigger the destination Lambda then you can set `log_group_permissions_prefix = log`, and then it will create 
+> only 1 permission for all of the log groups to trigger the destination Lambda, but you will still need to set `regex_pattern = log.*`. When using this parameter, you will not be able to see the log groups as triggers for the Lambda.
 
 ## Requirements
 

--- a/modules/lambda-manager/README.md
+++ b/modules/lambda-manager/README.md
@@ -39,9 +39,18 @@ This Lambda Function was created to pick up newly created and existing log group
 | notification_email | Failure notification email address | | |
 
 > [!Note]
-> In case the destination is lambda, then the code will add log groups that match the regex_pattern and then add them to the destination Lambda as triggers, each log group will also add permission to the Lambda, in some cases when there are a lot of log groups this will cause an error because the code tries to create too many permissions for the Lambda (AWS have a limitation for the number of permission that you can have for a Lambda), and this is why we have the `log_group_permissions_prefix` parameter, this parameter will add only permission to the Lambda 
-> using a wildcard( * ).for example, in case I have the log groups: log1,log2,log3 instead that the code will create for each of the log group permission to trigger the destination Lambda then you can set `log_group_permissions_prefix = log`, and then it will create 
-> only 1 permission for all of the log groups to trigger the destination Lambda, but you will still need to set `regex_pattern = log.*`. When using this parameter, you will not be able to see the log groups as triggers for the Lambda.
+> If the destination is a Lambda function, the code will identify log groups that match the specified `regex_pattern` and configure them as triggers for the destination Lambda. Each matching log group is also granted the necessary permission to invoke the Lambda.
+
+> However, when dealing with a large number of log groups, this process may result in an error. This occurs because the code attempts to create a separate permission for each log group, and AWS imposes a limit on the number of permissions that can be attached to a single Lambda function.
+
+> To address this limitation, the `log_group_permissions_prefix` parameter is used. Instead of creating individual permissions for each log group, this parameter allows you to assign a single wildcard-based permission to the Lambda function.
+
+> For example, if you have the log groups log1, log2, and log3, setting `log_group_permissions_prefix = log` will generate one permission using a wildcard (e.g., log*) to cover all matching log groups. This avoids exceeding AWS's permission limit for a Lambda function.
+
+> However, it's important to note that:
+>
+> - You must still set `regex_pattern = log.*` to match the desired log groups.
+> - When using `log_group_permissions_prefix`, the log groups will not appear as individual triggers on the Lambda function in the AWS Console, although they will still be able to invoke it.
 
 ## Requirements
 

--- a/modules/lambda-manager/main.tf
+++ b/modules/lambda-manager/main.tf
@@ -24,12 +24,12 @@ module "lambda" {
   create_package         = false
   destination_on_failure = aws_sns_topic.this.arn
   environment_variables = {
-    LOGS_FILTER        = var.logs_filter
-    REGEX_PATTERN      = var.regex_pattern
-    DESTINATION_ARN    = var.destination_arn
-    DESTINATION_ROLE   = var.destination_role
-    DESTINATION_TYPE   = var.destination_type
-    SCAN_OLD_LOGGROUPS = var.scan_old_loggroups
+    LOGS_FILTER                 = var.logs_filter
+    REGEX_PATTERN               = var.regex_pattern
+    DESTINATION_ARN             = var.destination_arn
+    DESTINATION_ROLE            = var.destination_role
+    DESTINATION_TYPE            = var.destination_type
+    SCAN_OLD_LOGGROUPS          = var.scan_old_loggroups
     LOG_GROUP_PERMISSION_PREFIX = local.log_groups_prefix_string
   }
   s3_existing_package = {

--- a/modules/lambda-manager/variables.tf
+++ b/modules/lambda-manager/variables.tf
@@ -1,3 +1,9 @@
+variable "log_group_permissions_prefix" {
+  description = "A list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the regex_pattern parameter."
+  type        = list(string)
+  default     = []
+}
+
 variable "regex_pattern" {
   description = "Set up this regex to match the Log Groups names that you want to automatically subscribe to the destination"
   type        = string


### PR DESCRIPTION
# Description
- Add missing permission to lambda to allow her to put permissions to the destination lambda
- Create a new variable `log_group_permissions_prefix`
-  Add trigger to the lambda that get create for the first time
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)