### PR TITLE
fix: fix an issue with newline_pattern variable to the shipper module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 #### **coralogix-aws-shipper**
 ### 🧰 Bug fixes 🧰
 - Fix an issue with `newline_pattern` variable, which is not showing in the env for the lambda.
+#### **lambda-manager**
+### 💡 Enhancements 💡
+- Add a default value to `logs_filter` to be an empty string
 
 ## v3.3.1
 #### **lambda-manager**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
+## v3.3.2
+#### **coralogix-aws-shipper**
+### 🧰 Bug fixes 🧰
+- Fix an issue with `newline_pattern` variable, which is not showing in the env for the lambda.
 
-## v3.4.2
+## v3.3.1
 #### **lambda-manager**
 ### 🧰 Bug fixes 🧰
 - Add missing permissions to lambda function
 ### 💡 Enhancements 💡
 - Add support for log_group_permissions_prefix variable
-
-## v3.4.1
 #### **firehose-logs**
 ###  💡 Configuration update 💡
 - Update buffering_size to be in line with documentation, use the value of 1MiB.
@@ -16,19 +18,15 @@
 ### 💡 Configuration update 💡
 - Update retry_duration to be in line with documentation, use the value of 300 seconds to secure we do not lose the data on any issues.
 
-## v3.4.0
+## v3.3.0
 #### **resource-metadata-sqs**
 ### 💡 Enhancements 💡
 - Add support for multi-region and cross-account metadata collection
 
-## v3.3.0
-#### **ecs-ec2**
-### 💡 Enhancements 💡
-- Updated ECS-EC2 default otel config with tarces head sampling
-
 ## v3.2.0
 #### **ecs-ec2**
 ### 💡 Enhancements 💡
+- Updated ECS-EC2 default otel config with tarces head sampling
 - Updated ECS-EC2 default otel config to use new collector metric config format
 - Added a transform to remove unneeded labels from metrics added as of otel v0.119.0
 

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -104,20 +104,15 @@ If you're deploying multiple integrations through the same S3 bucket, you'll nee
 | <a name="input_log_groups"></a> [log\_groups](#input\_log\_groups) | A comma-separated list of CloudWatch log group names to monitor. For example, (log-group1, log-group2, log-group3). | `list(string)` | n/a | yes |
 | <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) |  list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the `log_groups` parameter.  For more information, refer to the Note below. | `list(string)` | n/a | no |
 
-!!! !Note
+!!! note
 
-If the destination is a Lambda function, the code will identify log groups that match the specified `regex_pattern` and configure them as triggers for the destination Lambda. Each matching log group is also granted the necessary permission to invoke the Lambda.
+The `log_group` variable will get a list of log groups and then add them to the Lambda as triggers, each log group will also add permission to the Lambda, in some cases when there are a lot of log groups this will cause an error because the code 
+tries to create too many permissions for the Lambda (AWS have a limitation for the number of permission that you can have for a Lambda), and this is why we have the `log_group_prefix` parameter, this parameter will add **only** permission to the Lambda using a wildcard( * ).
 
-However, when dealing with a large number of log groups, this process may result in an error. This occurs because the code attempts to create a separate permission for each log group, and AWS imposes a limit on the number of permissions that can be attached to a single Lambda function.
+for example, in case I have the log groups: log1,log2,log3 instead that the code will create for each of the log group permission to trigger the shipper Lambda then you can set `log_group_prefix = ["log"]`, and then it will create only 1 permission for all of the log groups to trigger the shipper Lambda, but you will still need to set `log_groups = ["log1","log2","log3"]`. When using this parameter, you will not be able to see the log groups as triggers for the Lambda.
 
-To address this limitation, the `log_group_permissions_prefix` parameter is used. Instead of creating individual permissions for each log group, this parameter allows you to assign a single wildcard-based permission to the Lambda function.
+If you need to add multiple log groups to the Lambda function using regex, refer to our [Lambda manager](https://github.com/coralogix/terraform-coralogix-aws/tree/master/modules/lambda-manager)
 
-For example, if you have the log groups log1, log2, and log3, setting `log_group_permissions_prefix = log` will generate one permission using a wildcard (e.g., log*) to cover all matching log groups. This avoids exceeding AWS's permission limit for a Lambda function.
-
-However, it's important to note that:
-
-- You must still set `regex_pattern = log.*` to match the desired log groups.
-- When using `log_group_permissions_prefix`, the log groups will not appear as individual triggers on the Lambda function in the AWS Console, although they will still be able to invoke it.
 
 [//]: # (/description)
 

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -102,7 +102,22 @@ If you're deploying multiple integrations through the same S3 bucket, you'll nee
 | Name | Description | Type | Default | Required | 
 |------|-------------|------|---------|:--------:|
 | <a name="input_log_groups"></a> [log\_groups](#input\_log\_groups) | A comma-separated list of CloudWatch log group names to monitor. For example, (log-group1, log-group2, log-group3). | `list(string)` | n/a | yes |
-| <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) | Instead of creating one permission for each log group in the destination lambda, the code will take the prefix that you set in this parameter and create 1 permission for all of the log groups that match the prefix. For example, if you define `/aws/log/logs`, then the lLambda will create only 1 permission for all of your log groups that start with `/aws/log/logs` instead of 1 permision for each of the log group. Use this parameter when you have more than 50 log groups. Pay attention that you will not see the log groups as a trigger in the Lambda if you use this parameter. | `list(string)` | n/a | no |
+| <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) |  list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the `log_groups` parameter.  For more information, refer to the Note below. | `list(string)` | n/a | no |
+
+!!! !Note
+
+If the destination is a Lambda function, the code will identify log groups that match the specified `regex_pattern` and configure them as triggers for the destination Lambda. Each matching log group is also granted the necessary permission to invoke the Lambda.
+
+However, when dealing with a large number of log groups, this process may result in an error. This occurs because the code attempts to create a separate permission for each log group, and AWS imposes a limit on the number of permissions that can be attached to a single Lambda function.
+
+To address this limitation, the `log_group_permissions_prefix` parameter is used. Instead of creating individual permissions for each log group, this parameter allows you to assign a single wildcard-based permission to the Lambda function.
+
+For example, if you have the log groups log1, log2, and log3, setting `log_group_permissions_prefix = log` will generate one permission using a wildcard (e.g., log*) to cover all matching log groups. This avoids exceeding AWS's permission limit for a Lambda function.
+
+However, it's important to note that:
+
+- You must still set `regex_pattern = log.*` to match the desired log groups.
+- When using `log_group_permissions_prefix`, the log groups will not appear as individual triggers on the Lambda function in the AWS Console, although they will still be able to invoke it.
 
 [//]: # (/description)
 

--- a/modules/coralogix-aws-shipper/main.tf
+++ b/modules/coralogix-aws-shipper/main.tf
@@ -64,7 +64,7 @@ resource "aws_iam_policy" "lambda_policy" {
         {
           Effect   = "Allow",
           Action   = ["s3:PutObject", "s3:PutObjectAcl", "s3:AbortMultipartUpload", "s3:DeleteObject", "s3:PutObjectTagging", "s3:PutObjectVersionTagging"],
-          Resource = ["${data.aws_s3_bucket.dlq_bucket[0].arn}/*", data.aws_s3_bucket.dlq_bucket[0].arn] 
+          Resource = ["${data.aws_s3_bucket.dlq_bucket[0].arn}/*", data.aws_s3_bucket.dlq_bucket[0].arn]
         },
       ] : [],
 
@@ -103,7 +103,7 @@ resource "aws_iam_policy" "lambda_policy" {
           Resource = flatten([for bucket in data.aws_s3_bucket.this : ["${bucket.arn}/*", "${bucket.arn}"]])
         },
       ] : [],
-      
+
       # S3 Integration Policy
       local.s3_bucket_names != toset([]) && var.sqs_name == null ? [
         {

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -38,7 +38,7 @@ variable "subsystem_name" {
 variable "newline_pattern" {
   description = "The pattern for lines splitting"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "blocking_pattern" {

--- a/modules/lambda-manager/README.md
+++ b/modules/lambda-manager/README.md
@@ -27,7 +27,7 @@ This Lambda Function was created to pick up newly created and existing log group
 | Parameter | Description | Default Value | Required |
 |-----------|-------------|---------------|----------|
 | regex_pattern | Set up this regex to match the Log Groups names that you want to automatically subscribe to the destination| | yes |
-| logs_filter | Subscription filter to select which logs needs to be sent to Coralogix. For Example for Lambda Errors that are not sendable by Coralogix Lambda Layer '?REPORT ?"Task timed out" ?"Process exited before completing" ?errorMessage ?"module initialization error:" ?"Unable to import module" ?"ERROR Invoke Error" ?"EPSAGON_TRACE:"'. | | yes |
+| logs_filter | Subscription filter to select which logs needs to be sent to Coralogix. For Example for Lambda Errors that are not sendable by Coralogix Lambda Layer '?REPORT ?"Task timed out" ?"Process exited before completing" ?errorMessage ?"module initialization error:" ?"Unable to import module" ?"ERROR Invoke Error" ?"EPSAGON_TRACE:"'. |  | no |
 | log_group_permissions_prefix | A list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the regex_pattern parameter.  For more information, refer to the Note below.| | no |
 | destination_arn | Arn for the firehose to subscribe the log groups (By default, is the firehose created by Serverless Template) | | yes |
 | destination_role | Arn for the role to allow destination subscription to be pushed (In case you use Firehose) | n/a | no |

--- a/modules/lambda-manager/main.tf
+++ b/modules/lambda-manager/main.tf
@@ -99,7 +99,7 @@ resource "aws_sns_topic_subscription" "this" {
   endpoint   = var.notification_email
 }
 
-resource "aws_lambda_invocation" "example" {
+resource "aws_lambda_invocation" "trigger_lambda_for_first_time" {
   function_name = module.lambda.lambda_function_arn
   input = jsonencode({
     RequestType = "Create"

--- a/modules/lambda-manager/variables.tf
+++ b/modules/lambda-manager/variables.tf
@@ -18,6 +18,7 @@ variable "destination_role" {
 variable "logs_filter" {
   description = "Subscription filter to select which logs needs to be sent to Coralogix. For Example for Lambda Errors that are not sendable by Coralogix Lambda Layer '?REPORT ?\"Task timed out\" ?\"Process exited before completing\" ?errorMessage ?\"module initialization error:\" ?\"Unable to import module\" ?\"ERROR Invoke Error\" ?\"EPSAGON_TRACE:\"'."
   type        = string
+  default     = ""
 }
 
 variable "destination_arn" {


### PR DESCRIPTION
# Description
The PR has the following changes:
- fix an issue with the newline_pattern variable in the shipper module, where it's not adding this as an env to the lambda after applying the variable, and change the default value to null instead of an empty string.
- Change the default value for `logs_filter` variable in the lambda-manager module to be an empty string so it will no longer be required.
- Update description for the `log_group_prefix` variable, so it will be clearer.
- Change the permissions creation for the shipper module, so it will not create a CW permission by default, and will use a better logic to add the permissions
- Align the changelog with the module's current versions

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)