### PR TITLE
fix: Update the required terraform version for the modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v3.3.4
+#### **coralogix-aws-shipper**, **firehose-metrics**, **firehose-logs**, **ecs-ec2**
+### 🧰 Bug fixes 🧰
+- Update the required version of the modules:
+  - coralogix-aws-shipper: >= 1.7.0
+  - firehose-metrics: >= 1.6.0
+  - firehose-logs: >= 1.6.0
+  - ecs-ec2: >= 1.9.0
+
 ## v3.3.3
 #### **coralogix-aws-shipper**
 ### 🧰 Bug fixes 🧰

--- a/examples/coralogix-aws-shipper/README.md
+++ b/examples/coralogix-aws-shipper/README.md
@@ -152,8 +152,9 @@ module "coralogix-shipper-multiple-s3-integrations" {
 [//]: # (/example)
 
 [//]: # (example id="CloudWatch-integration")
+## Configuration examples
 
-### Configuration example
+### CloudWatch (default)
 ```bash
 module "coralogix-shipper-cloudwatch" {
   source = "coralogix/aws/coralogix//modules/coralogix-aws-shipper"
@@ -166,6 +167,38 @@ module "coralogix-shipper-cloudwatch" {
   log_groups         = ["log_gruop"]
 }
 ```
+
+### CloudWatch with lambda-manager
+
+In some cases, you will have a large number of log groups that you would like to monitor.
+In this case, instead of adding the log groups manually, you can use the lambda-manager to add a subscription to your coralogix-shipper lambda using a regex.
+Pay attention that the lambda-manager will also add new log groups to the integration automatically.
+For more information, please refer to the [lambda-manager](https://github.com/coralogix/terraform-coralogix-aws/blob/master/modules/lambda-manager/README.md)
+```bash
+module "coralogix-shipper-cloudwatch" {
+  source = "coralogix/aws/coralogix//modules/coralogix-aws-shipper"
+
+  coralogix_region   = "EU1"
+  integration_type   = "CloudWatch"
+  api_key            = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
+  application_name   = "cloudwatch-application"
+  subsystem_name     = "cloudwatch-subsystem"
+  log_groups         = ["log_gruop"]
+}
+
+module "coralogix-lambda-manager" {
+  source = "coralogix/aws/coralogix//modules/lambda-manager"
+
+  regex_pattern                = "log_groups_name*"
+  destination_arn              = module.coralogix-shipper-cloudwatch.lambda_function_arn[0]
+  destination_type             = "lambda"
+  scan_old_loggroups           = true
+  log_group_permissions_prefix = ["log_groups_name"]
+}
+
+```
+Important note: the `log_group_permissions_prefix` is optional, and will ONLY add permissions to the lambda and will not add the subscription.
+For more information about the variables, please refer to the [lambda-manager README](https://github.com/coralogix/terraform-coralogix-aws/tree/master/modules/lambda-manager#environment-variables)
 
 [//]: # (/example)
 

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -175,7 +175,7 @@ If you need to add multiple log groups to the Lambda function using regex, refer
 | Name | Description | Type | Default | Required | 
 |------|-------------|------|---------|:--------:|
 | <a name="input_custom_metadata"></a> [custom\_metadata](#input\_custom\_metadata) | Custom metadata to be added to the log message in the comma-separated format. Options are: `key1=value1,key2=value2` | `string` | n/a | no |
-| <a name="input_add_metadata"></a> [add\_metadata](#input\_add\_metadata) | Custom metadata to be added to the log message in the comma-separated format. The S3 options are: `bucket_name`,`key_name`. For CloudWatch `stream_name` | `string` | n/a | no |
+| <a name="input_add_metadata"></a> [add\_metadata](#input\_add\_metadata) | Custom metadata to be added to the log message in the comma-separated format. The S3 options are: `bucket_name`,`key_name`. For CloudWatch `stream_name`, `loggroup_name`. For Kafka/MSK, use `topic_name` | `string` | n/a | no |
 | <a name="input_lambda_name"></a> [lambda\_name](#input\_lambda\_name) | The name the Lambda function to create. | `string` | n/a | no |
 | <a name="input_blocking_pattern"></a> [blocking\_pattern](#input\_blocking\_pattern) | A regular expression to identify lines excluded from being sent to Coralogix. For example, use `MainActivity.java:\d{3}` to match log lines with MainActivity followed by exactly three digits. | `string` | n/a | no |
 | <a name="input_sampling_rate"></a> [sampling\_rate](#input\_sampling\_rate) | A message rate, such as 1 out of every N logs. For example, if your value is 10, a message will be sent for every 10th log. | `number` | `1` | no |

--- a/modules/coralogix-aws-shipper/versions.tf
+++ b/modules/coralogix-aws-shipper/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.7.0"
 
   required_providers {
     aws = {

--- a/modules/ecs-ec2/versions.tf
+++ b/modules/ecs-ec2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.1"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.6.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.6.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
# Description
- Update the required version of the modules:
  - coralogix-aws-shipper: >= 1.7.0
  - firehose-metrics: >= 1.6.0
  - firehose-logs: >= 1.6.0
  - ecs-ec2: >= 1.9.0
- Add an example for CloudWatch integration with Lambda Manager
- Update the `add_metadata` variable description to include missing option
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #237 

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)