### PR TITLE
feat: create add_permissions_to_all_log_groups variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
-## v3.3.5
+## v3.5.0
+#### **lambda-manager**
+### 💡 Enhancements 💡
+- Add add_permissions_to_all_log_groups variable, When set to true, grants subscription permissions to the destination for all current and future log groups using a wildcard
+
+## v3.4.0
 #### **lambda-manager**
 ### 💡 Enhancements 💡
 - Add  disable_add_permission variable
 
 
-## v3.3.5
+## v3.4.0
 #### **resource-metadata-sqs**
 ### 💡 Configuration update 💡
 - Update the module according to the function's latest release (v0.3.0)

--- a/examples/lambda-manager/variables.tf
+++ b/examples/lambda-manager/variables.tf
@@ -1,3 +1,15 @@
+variable "log_group_permissions_prefix" {
+  description = "A list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the regex_pattern parameter."
+  type        = list(string)
+  default     = []
+}
+
+variable "disable_add_permission" {
+  description = "Disable the add permission to the destination loggroup"
+  type        = bool
+  default     = false
+}
+
 variable "regex_pattern" {
   description = "Set up this regex to match the Log Groups names that you want to automatically subscribe to the destination"
   type        = string
@@ -12,6 +24,7 @@ variable "destination_role" {
 variable "logs_filter" {
   description = "Subscription filter to select which logs needs to be sent to Coralogix. For Example for Lambda Errors that are not sendable by Coralogix Lambda Layer '?REPORT ?\"Task timed out\" ?\"Process exited before completing\" ?errorMessage ?\"module initialization error:\" ?\"Unable to import module\" ?\"ERROR Invoke Error\" ?\"EPSAGON_TRACE:\"'."
   type        = string
+  default     = ""
 }
 
 variable "destination_arn" {
@@ -26,6 +39,12 @@ variable "destination_type" {
 
 variable "scan_old_loggroups" {
   description = "This will scan all LogGroups in the account and apply the subscription configured, will only run Once and set to false. Default is false"
+  type        = string
+  default     = "false"
+}
+
+variable "add_permissions_to_all_log_groups" {
+  description = "When set to true, grants subscription permissions to the destination for all current and future log groups using a wildcard"
   type        = string
   default     = "false"
 }

--- a/modules/lambda-manager/README.md
+++ b/modules/lambda-manager/README.md
@@ -33,6 +33,7 @@ This Lambda Function was created to pick up newly created and existing log group
 | destination_role | Arn for the role to allow destination subscription to be pushed (In case you use Firehose) | n/a | no |
 | destination_type | Type of destination (Lambda or Firehose) | | yes |
 | scan_old_loggroups | This will scan all LogGroups in the account and apply the subscription configured, will only run Once and set to false. Default is false | false | yes |
+| add_permissions_to_all_log_groups | When set to true, grants subscription permissions to the destination for all current and future log groups using a wildcard | false | |
 | disable_add_permission | Disable add permission to loggroup| false | |
 | architecture | Lambda function architecture, possible options are [x86_64, arm64] | x86_64 | |
 | memory_size | The maximum allocated memory this lambda may consume. Default value is the minimum recommended setting please consult coralogix support before changing. | 1024 |  |

--- a/modules/lambda-manager/main.tf
+++ b/modules/lambda-manager/main.tf
@@ -24,14 +24,15 @@ module "lambda" {
   create_package         = false
   destination_on_failure = aws_sns_topic.this.arn
   environment_variables = {
-    LOGS_FILTER                 = var.logs_filter
-    REGEX_PATTERN               = var.regex_pattern
-    DESTINATION_ARN             = var.destination_arn
-    DESTINATION_ROLE            = var.destination_role
-    DESTINATION_TYPE            = var.destination_type
-    SCAN_OLD_LOGGROUPS          = var.scan_old_loggroups
-    LOG_GROUP_PERMISSION_PREFIX = local.log_groups_prefix_string
-    DISABLE_ADD_PERMISSION = var.disable_add_permission
+    LOGS_FILTER                       = var.logs_filter
+    REGEX_PATTERN                     = var.regex_pattern
+    DESTINATION_ARN                   = var.destination_arn
+    DESTINATION_ROLE                  = var.destination_role
+    DESTINATION_TYPE                  = var.destination_type
+    SCAN_OLD_LOGGROUPS                = var.scan_old_loggroups
+    LOG_GROUP_PERMISSION_PREFIX       = local.log_groups_prefix_string
+    DISABLE_ADD_PERMISSION            = var.disable_add_permission
+    ADD_PERMISSIONS_TO_ALL_LOG_GROUPS = var.add_permissions_to_all_log_groups
   }
   s3_existing_package = {
     bucket = "coralogix-serverless-repo-${data.aws_region.this.name}"

--- a/modules/lambda-manager/variables.tf
+++ b/modules/lambda-manager/variables.tf
@@ -43,6 +43,12 @@ variable "scan_old_loggroups" {
   default     = "false"
 }
 
+variable "add_permissions_to_all_log_groups" {
+  description = "When set to true, grants subscription permissions to the destination for all current and future log groups using a wildcard"
+  type        = string
+  default     = "false"
+}
+
 variable "memory_size" {
   description = "The maximum allocated memory this lambda may consume. Default value is the minimum recommended setting please consult coralogix support before changing."
   type        = number


### PR DESCRIPTION
# Description
- Add a new variable `add_permissions_to_all_log_groups`, When set to true, grants subscription permissions to the destination for all current and future log groups using a wildcard.
- sync examples variables file with the modules variables file 
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)