### PR TITLE
feat: add SSE to kinesis firehose

### DIFF
--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -129,6 +129,19 @@ variable "kinesis_stream_name" {
   default     = null
 }
 
+variable "kinesis_server_side_encryption" {
+  description = "Server side encryption configuration"
+  type = object({
+    enabled  = bool
+    key_type = optional(string)
+    key_arn  = optional(string)
+  })
+  default = {
+    enabled  = false
+    key_type = "AWS_OWNED_CMK"
+  }
+}
+
 # MSK variables
 
 variable "msk_cluster_arn" {

--- a/examples/firehose-logs/firehose-logs.tf
+++ b/examples/firehose-logs/firehose-logs.tf
@@ -7,4 +7,5 @@ module "cloudwatch_firehose_logs_coralogix" {
   source_type_logs          = "DirectPut"
   user_supplied_tags        = var.user_supplied_tags
   cloudwatch_retention_days = var.cloudwatch_retention_days
+  server_side_encryption    = var.server_side_encryption
 }

--- a/examples/firehose-logs/variables.tf
+++ b/examples/firehose-logs/variables.tf
@@ -62,3 +62,16 @@ variable "govcloud_deployment" {
   type        = bool
   default     = false
 }
+
+variable "server_side_encryption" {
+  description = "Server side encryption configuration"
+  type = object({
+    enabled  = bool
+    key_type = optional(string)
+    key_arn  = optional(string)
+  })
+  default = {
+    enabled  = false
+    key_type = "AWS_OWNED_CMK"
+  }
+}

--- a/examples/firehose-metrics/firehose-metrics.tf
+++ b/examples/firehose-metrics/firehose-metrics.tf
@@ -13,4 +13,5 @@ module "cloudwatch_firehose_metrics_coralogix" {
   coralogix_region                    = var.coralogix_region
   user_supplied_tags                  = var.user_supplied_tags
   cloudwatch_retention_days           = var.cloudwatch_retention_days
+  server_side_encryption              = var.server_side_encryption
 }

--- a/examples/firehose-metrics/variables.tf
+++ b/examples/firehose-metrics/variables.tf
@@ -133,3 +133,16 @@ variable "govcloud_deployment" {
   type        = bool
   default     = false
 }
+
+variable "server_side_encryption" {
+  description = "Server side encryption configuration"
+  type = object({
+    enabled  = bool
+    key_type = optional(string)
+    key_arn  = optional(string)
+  })
+  default = {
+    enabled  = false
+    key_type = "AWS_OWNED_CMK"
+  }
+}

--- a/modules/coralogix-aws-shipper/firehose.tf
+++ b/modules/coralogix-aws-shipper/firehose.tf
@@ -160,4 +160,10 @@ resource "aws_kinesis_firehose_delivery_stream" "extended_s3_stream" {
       log_stream_name = aws_cloudwatch_log_stream.firehose_log_stream[0].name
     }
   }
+
+  server_side_encryption {
+    enabled  = var.server_side_encryption.enabled
+    key_type = var.server_side_encryption.key_type
+    key_arn  = var.server_side_encryption.key_arn
+  }
 }

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -130,6 +130,24 @@ variable "kinesis_stream_name" {
   default     = null
 }
 
+variable "kinesis_server_side_encryption" {
+  description = "Server side encryption configuration"
+  type = object({
+    enabled  = bool
+    key_type = optional(string)
+    key_arn  = optional(string)
+  })
+  default = {
+    enabled  = false
+    key_type = "AWS_OWNED_CMK"
+  }
+
+  validation {
+    condition = contains(["AWS_OWNED_CMK", "CUSTOMER_MANAGED_CMK"], var.server_side_encryption.key_type)
+    error_message = "Valid values for key_type are AWS_OWNED_CMK and CUSTOMER_MANAGED_CMK."
+  }
+}
+
 # MSK variables
 
 variable "msk_cluster_arn" {

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -277,4 +277,10 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_logs" {
       }
     }
   }
+
+  server_side_encryption {
+    enabled  = var.server_side_encryption.enabled
+    key_type = var.server_side_encryption.key_type
+    key_arn  = var.server_side_encryption.key_arn
+  }
 }

--- a/modules/firehose-logs/variables.tf
+++ b/modules/firehose-logs/variables.tf
@@ -107,3 +107,21 @@ variable "s3_enable_secure_transport" {
   type        = bool
   default     = true
 }
+
+variable "server_side_encryption" {
+  description = "Server side encryption configuration"
+  type = object({
+    enabled  = bool
+    key_type = optional(string)
+    key_arn  = optional(string)
+  })
+  default = {
+    enabled  = false
+    key_type = "AWS_OWNED_CMK"
+  }
+
+  validation {
+    condition = contains(["AWS_OWNED_CMK", "CUSTOMER_MANAGED_CMK"], var.server_side_encryption.key_type)
+    error_message = "Valid values for key_type are AWS_OWNED_CMK and CUSTOMER_MANAGED_CMK."
+  }
+}

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -406,6 +406,12 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_metrics" {
 
     }
   }
+
+  server_side_encryption {
+    enabled  = var.server_side_encryption.enabled
+    key_type = var.server_side_encryption.key_type
+    key_arn  = var.server_side_encryption.key_arn
+  }
 }
 
 ################################################################################

--- a/modules/firehose-metrics/variables.tf
+++ b/modules/firehose-metrics/variables.tf
@@ -223,3 +223,21 @@ variable "custom_s3_bucket" {
   type        = string
   default     = null
 }
+
+variable "server_side_encryption" {
+  description = "Server side encryption configuration"
+  type = object({
+    enabled  = bool
+    key_type = optional(string)
+    key_arn  = optional(string)
+  })
+  default = {
+    enabled  = false
+    key_type = "AWS_OWNED_CMK"
+  }
+
+  validation {
+    condition = contains(["AWS_OWNED_CMK", "CUSTOMER_MANAGED_CMK"], var.server_side_encryption.key_type)
+    error_message = "Valid values for key_type are AWS_OWNED_CMK and CUSTOMER_MANAGED_CMK."
+  }
+}


### PR DESCRIPTION
# Description

Added Server-Side Encryption (SSE) support to Kinesis Firehose delivery streams

# How Has This Been Tested?

The changes have been tested by copying these modules to a private infrastructure repository and testing them there

# Checklist:
- [X] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)