### PR TITLE
Pin versions to NOT use aws provider v6 in resource-metadata module

### DIFF
--- a/modules/resource-metadata/README.md
+++ b/modules/resource-metadata/README.md
@@ -16,7 +16,7 @@ Manage the application which retrieves `meta data` from your aws account and sen
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.15.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.15.1, < 6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.0 |
 
 ## Modules

--- a/modules/resource-metadata/main.tf
+++ b/modules/resource-metadata/main.tf
@@ -54,6 +54,7 @@ data "aws_partition" "current" {}
 
 module "eventbridge" {
   source = "terraform-aws-modules/eventbridge/aws"
+  version = "3.17.1"
 
   create_bus  = false
   create_role = false

--- a/modules/resource-metadata/versions.tf
+++ b/modules/resource-metadata/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.15.1"
+      version = ">= 4.15.1, < 6.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
# Description

Currently, there are some inconsistencies in the different modules. Some explicitly enforce aws provider with version < 6.0, others do not provide any version hint.

In the resource-metadata module, this caused problems now , because the 3rd party eventbridge module was not pinned to any version, but in the newest version, this module needs aws provider version >= 6.0.

So as result, you couldn't mix coralogix modules in one terraform module (like resource-metadata and firehose-logs), because terraform could not find a matching provider version.

# How Has This Been Tested?

I cloned the repository and used a local version in my terraform project.

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [X ] This change does not affect module (e.g. it's readme file change)