### PR TITLE
fix(s3-archive): Add bucket ids for s3 archive module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## v3.10.3
+#### **s3-archive**
+### 💡 Enhancements 💡
+- Added `logs_bucket_id` and `metrics_bucket_id` outputs.
+
 ## v3.10.2
 #### **coralogix-aws-shipper**
 ### 💡 Enhancements 💡

--- a/examples/s3-archive/README.md
+++ b/examples/s3-archive/README.md
@@ -19,3 +19,12 @@ module "s3-archive" {
   metrics_bucket_name = "<your bucket name>"
 }
 ```
+
+## Available Outputs
+
+The module provides bucket IDs as outputs for external configuration:
+
+- `logs_bucket_id` - ID of the created logs S3 bucket
+- `metrics_bucket_id` - ID of the created metrics S3 bucket
+
+These outputs can be used to configure S3 lifecycle policies, intelligent tiering, or other bucket-level configurations externally.

--- a/examples/s3-archive/outputs.tf
+++ b/examples/s3-archive/outputs.tf
@@ -9,3 +9,14 @@ output "logs_kms_problem" {
 output "metrics_kms_problem" {
   value = var.metrics_kms_arn == "" || contains(split(":", var.metrics_kms_arn), var.aws_region) ? "" : "The KMS that you specified for metrics is not in the same region as your aws_region"
 }
+
+# Bucket outputs for external lifecycle configuration
+output "logs_bucket_id" {
+  value       = local.logs_validations ? aws_s3_bucket.logs_bucket_name[0].id : null
+  description = "ID of the created logs S3 bucket"
+}
+
+output "metrics_bucket_id" {
+  value       = local.metrics_validations ? aws_s3_bucket.metrics_bucket_name[0].id : null
+  description = "ID of the created metrics S3 bucket"
+}

--- a/examples/s3-archive/outputs.tf
+++ b/examples/s3-archive/outputs.tf
@@ -10,7 +10,6 @@ output "metrics_kms_problem" {
   value = var.metrics_kms_arn == "" || contains(split(":", var.metrics_kms_arn), var.aws_region) ? "" : "The KMS that you specified for metrics is not in the same region as your aws_region"
 }
 
-# Bucket outputs for external lifecycle configuration
 output "logs_bucket_id" {
   value       = local.logs_validations ? aws_s3_bucket.logs_bucket_name[0].id : null
   description = "ID of the created logs S3 bucket"

--- a/examples/s3-archive/outputs.tf
+++ b/examples/s3-archive/outputs.tf
@@ -9,13 +9,3 @@ output "logs_kms_problem" {
 output "metrics_kms_problem" {
   value = var.metrics_kms_arn == "" || contains(split(":", var.metrics_kms_arn), var.aws_region) ? "" : "The KMS that you specified for metrics is not in the same region as your aws_region"
 }
-
-output "logs_bucket_id" {
-  value       = local.logs_validations ? aws_s3_bucket.logs_bucket_name[0].id : null
-  description = "ID of the created logs S3 bucket"
-}
-
-output "metrics_bucket_id" {
-  value       = local.metrics_validations ? aws_s3_bucket.metrics_bucket_name[0].id : null
-  description = "ID of the created metrics S3 bucket"
-}

--- a/modules/provisioning/s3-archive/README.md
+++ b/modules/provisioning/s3-archive/README.md
@@ -17,6 +17,8 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.15.1 |
 
+## Variables
+
 | Variable name | Description | Type | Default | Required | 
 |---------------|-------------|------|---------|:--------:|
 | aws_region | The AWS region that you want to create the S3 bucket, Must be the same as the AWS region where your [coralogix account](https://coralogix.com/docs/coralogix-domain/) is set. Allowd values: eu-west-1, eu-north-1, ap-southeast-1,ap-southeast-1, ap-south-1, us-east-2, us-west-2 | `string` | n/a | :heavy_check_mark: |
@@ -26,3 +28,13 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 | metrics_bucket_force_destroy | enable force destroy to the metrics S3 bucekt, to not allow delete if there is files in the bucket | `bool` | false | |
 | logs_kms_arn |  The arn of your kms for the logs bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |
 | metrics_kms_arn | The arn of your kms for the metrics bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |
+
+## Outputs
+
+| Output name | Description | Type |
+|-------------|-------------|------|
+| logs_bucket_id | ID of the created logs S3 bucket (null if not created). | `string` |
+| metrics_bucket_id | ID of the created metrics S3 bucket (null if not created). | `string` |
+| wrong_region | Validation message if an unsupported region is used | `string` |
+| logs_kms_problem | Validation message if the logs KMS key is not in the same region | `string` |
+| metrics_kms_problem | Validation message if the metrics KMS key is not in the same region | `string` |

--- a/modules/provisioning/s3-archive/outputs.tf
+++ b/modules/provisioning/s3-archive/outputs.tf
@@ -9,3 +9,14 @@ output "logs_kms_problem" {
 output "metrics_kms_problem" {
   value = var.metrics_kms_arn == "" || contains(split(":", var.metrics_kms_arn), var.aws_region) ? "" : "The KMS that you specified for metrics is not in the same region as your aws_region"
 }
+
+# Bucket outputs for external lifecycle configuration
+output "logs_bucket_id" {
+  value       = local.logs_validations ? aws_s3_bucket.logs_bucket_name[0].id : null
+  description = "ID of the created logs S3 bucket"
+}
+
+output "metrics_bucket_id" {
+  value       = local.metrics_validations ? aws_s3_bucket.metrics_bucket_name[0].id : null
+  description = "ID of the created metrics S3 bucket"
+}

--- a/modules/provisioning/s3-archive/outputs.tf
+++ b/modules/provisioning/s3-archive/outputs.tf
@@ -10,7 +10,6 @@ output "metrics_kms_problem" {
   value = var.metrics_kms_arn == "" || contains(split(":", var.metrics_kms_arn), var.aws_region) ? "" : "The KMS that you specified for metrics is not in the same region as your aws_region"
 }
 
-# Bucket outputs for external lifecycle configuration
 output "logs_bucket_id" {
   value       = local.logs_validations ? aws_s3_bucket.logs_bucket_name[0].id : null
   description = "ID of the created logs S3 bucket"


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> 

 Related to this issue https://github.com/coralogix/terraform-coralogix-aws/issues/259. Instead of adding configurable tiering, adding bucket ids to the module makes it easier for the customer to attach configuration on those buckets. E.g. 
 
```
module "s3_archive" {
  source = "coralogix/aws/coralogix//modules/provisioning/s3-archive"
  
  aws_region          = "us-east-2"
  logs_bucket_name    = "my-logs-bucket"    # or null
  metrics_bucket_name = "my-metrics-bucket" # or null
}

# Configure intelligent tiering for any created buckets
resource "aws_s3_bucket_intelligent_tiering_configuration" "logs" {
  count  = module.s3_archive.logs_bucket_id != null ? 1 : 0
  bucket = module.s3_archive.logs_bucket_id
  name   = "intelligent_tiering"
  status = "Enabled"
  
  tiering {
    access_tier = "ARCHIVE_ACCESS"
    days        = 90
  }
}
```

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)