### PR TITLE
fix: Update ECS-EC2 api key variable name to align with UI

### DIFF
--- a/modules/ecs-ec2-tail-sampling/main.tf
+++ b/modules/ecs-ec2-tail-sampling/main.tf
@@ -219,7 +219,7 @@ resource "aws_ecs_task_definition" "agent" {
         value : local.coralogix_domain
       },
       {
-        name : "PRIVATE_KEY"
+        name : "CORALOGIX_PRIVATE_KEY"
         value : var.api_key
       },
       {
@@ -229,6 +229,10 @@ resource "aws_ecs_task_definition" "agent" {
       {
         name : "SUB_SYS"
         value : var.default_subsystem_name
+      },
+      {
+        name : "MY_POD_IP"
+        value : "0.0.0.0"
       }
     ],
     command : [
@@ -300,7 +304,7 @@ resource "aws_ecs_task_definition" "gateway" {
         Value : local.coralogix_domain
       },
       {
-        Name : "PRIVATE_KEY"
+        Name : "CORALOGIX_PRIVATE_KEY"
         Value : var.api_key
       },
       {
@@ -310,6 +314,10 @@ resource "aws_ecs_task_definition" "gateway" {
       {
         Name : "SUB_SYS"
         Value : var.default_subsystem_name
+      },
+      {
+        Name : "MY_POD_IP"
+        Value : "0.0.0.0"
       }
     ]
 
@@ -388,7 +396,7 @@ resource "aws_ecs_task_definition" "receiver" {
         Value : local.coralogix_domain
       },
       {
-        Name : "PRIVATE_KEY"
+        Name : "CORALOGIX_PRIVATE_KEY"
         Value : var.api_key
       },
       {
@@ -398,6 +406,10 @@ resource "aws_ecs_task_definition" "receiver" {
       {
         Name : "SUB_SYS"
         Value : var.default_subsystem_name
+      },
+      {
+        Name : "MY_POD_IP"
+        Value : "0.0.0.0"
       }
     ]
 

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -190,7 +190,7 @@ resource "aws_ecs_task_definition" "coralogix_otel_agent" {
         value : local.otel_config
       }] : [],
       var.use_api_key_secret != true ? [{
-        name : "PRIVATE_KEY"
+        name : "CORALOGIX_PRIVATE_KEY"
         value : var.api_key
     }] : []),
     secrets : concat(
@@ -199,7 +199,7 @@ resource "aws_ecs_task_definition" "coralogix_otel_agent" {
         valueFrom : var.custom_config_parameter_store_name
       }] : [],
       var.use_api_key_secret == true ? [{
-        name : "PRIVATE_KEY"
+        name : "CORALOGIX_PRIVATE_KEY"
         valueFrom : var.api_key_secret_arn
       }] : []
     ),

--- a/modules/ecs-ec2/otel_config.tftpl.yaml
+++ b/modules/ecs-ec2/otel_config.tftpl.yaml
@@ -242,7 +242,7 @@ connectors:
 exporters:
   coralogix:
     domain: $${CORALOGIX_DOMAIN}
-    private_key: $${PRIVATE_KEY}
+    private_key: $${CORALOGIX_PRIVATE_KEY}
     application_name: $${APP_NAME}
     subsystem_name: $${SUB_SYS}
     application_name_attributes:
@@ -257,7 +257,7 @@ exporters:
   coralogix/resource_catalog:
     application_name: resource
     domain: $${CORALOGIX_DOMAIN}
-    private_key: $${PRIVATE_KEY}
+    private_key: $${CORALOGIX_PRIVATE_KEY}
     logs:
       headers:
         X-Coralogix-Distribution: ecs-ec2-integration/1.0.0


### PR DESCRIPTION
# Description

To align with UI integration which will provide otel config using helm we need to update the module  var.api_key to CORALOGIX_PRIVATE_KEY 

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)