### PR TITLE
chore: migrate firehose-metrics lambda to the common S3 repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.12.1
+#### **firehose-metrics**
+### 🔧 Maintenance 🔧
+- Migrate Lambda ZIP package to the common serverless repo bucket `coralogix-serverless-repo`
+
 ## v3.12.0
 #### **coralogix-aws-shipper**
 ### 💡 Enhancements 💡

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -60,7 +60,7 @@ resource "null_resource" "s3_bucket_copy" {
 
   provisioner "local-exec" {
     command = <<-EOF
-      curl -o bootstrap.zip https://cx-cw-metrics-tags-lambda-processor-eu-west-1.s3.eu-west-1.amazonaws.com/bootstrap.zip
+      curl -o bootstrap.zip https://coralogix-serverless-repo-eu-west-1.s3.eu-west-1.amazonaws.com/firehose-metrics-transformer.zip
       aws s3 cp --region ${data.aws_region.current_region.id} ./bootstrap.zip s3://${var.custom_s3_bucket}
       if [ -f bootstrap.zip ]; then
         rm ./bootstrap.zip
@@ -304,8 +304,8 @@ resource "aws_cloudwatch_log_group" "loggroup" {
 resource "aws_lambda_function" "lambda_processor" {
   depends_on    = [null_resource.s3_bucket_copy]
   count         = var.lambda_processor_enable ? 1 : 0
-  s3_bucket     = coalesce(var.custom_s3_bucket, "cx-cw-metrics-tags-lambda-processor-${data.aws_region.current_region.id}")
-  s3_key        = "bootstrap.zip"
+  s3_bucket     = coalesce(var.custom_s3_bucket, "coralogix-serverless-repo-${data.aws_region.current_region.id}")
+  s3_key        = "firehose-metrics-transformer.zip"
   function_name = local.lambda_processor_name
   role          = local.lambda_processor_iam_role_arn
   handler       = "bootstrap"


### PR DESCRIPTION
# Description

Fixes CDS-1821 by moving `firehose-metrics-transformation` Lambda to `coralogix-serverless-repo` bucket, where all other functions are deployed. 

# How Has This Been Tested?

Tested the module by making sure it can pull the Lambda from the new location.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)