### PR TITLE
fix: update node.js version to 22.x in resource-metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.14.1
+#### **resource-metadata**
+### 🔧 Maintenance 🔧
+- Update Node.js runtime version to 22.x.
+
 ## v3.14.0
 #### **Multiple Modules**
 ### 🔧 Maintenance 🔧

--- a/modules/resource-metadata/main.tf
+++ b/modules/resource-metadata/main.tf
@@ -96,7 +96,7 @@ module "lambda" {
   layers                 = var.secret_manager_enabled ? [var.layer_arn] : []
   description            = "Send metadata to Coralogix."
   handler                = "index.handler"
-  runtime                = "nodejs20.x"
+  runtime                = "nodejs22.x"
   architectures          = [var.architecture]
   memory_size            = var.memory_size
   timeout                = var.timeout


### PR DESCRIPTION
# Description

Fixes CDS-2570 by updating Node.js version to 22.x in `resource-metadata` module

# How Has This Been Tested?

Run the function with updated Node.js version to make sure it runs as expected and provides a desired output.