### PR TITLE
feat: [CDS-2663] Add log_group_filter_pattern variable for CloudWatch subscription filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.15.1
+#### **coralogix-aws-shipper**
+### 💡 Enhancements 💡
+- Added `log_group_filter_pattern` variable to allow customers to specify a filter pattern for CloudWatch log subscription filters. This enables filtering which logs are sent to Coralogix instead of forwarding all log events.
+
 ## v3.15.0
 #### **firehose-metrics**
 ### 💡 Enhancements 💡

--- a/modules/coralogix-aws-shipper/CloudWatch.tf
+++ b/modules/coralogix-aws-shipper/CloudWatch.tf
@@ -13,5 +13,5 @@ resource "aws_cloudwatch_log_subscription_filter" "this" {
   name            = "${module.lambda.integration.lambda_function_name}-Subscription-${each.key}"
   log_group_name  = data.aws_cloudwatch_log_group.this[each.key].name
   destination_arn = module.lambda.integration.lambda_function_arn
-  filter_pattern  = ""
+  filter_pattern  = var.log_group_filter_pattern
 }

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -101,6 +101,7 @@ If you're deploying multiple integrations through the same S3 bucket, you'll nee
 |------|-------------|------|---------|:--------:|
 | <a name="input_log_groups"></a> [log\_groups](#input\_log\_groups) | A comma-separated list of CloudWatch log group names to monitor. For example, (log-group1, log-group2, log-group3). | `list(string)` | n/a | yes |
 | <a name="input_log_group_prefix"></a> [log\_group\_prefix](#input\_log\_group\_prefix) |  list of strings of log group prefixes. The code will use these prefixes to create permissions for the Lambda instead of creating for each log group permission it will use the prefix with a wild card to give the Lambda access for all of the log groups that start with these prefix. This parameter doesn't replace the `log_groups` parameter.  For more information, refer to the Note below. | `list(string)` | n/a | no |
+| <a name="input_log_group_filter_pattern"></a> [log\_group\_filter\_pattern](#input\_log\_group\_filter\_pattern) | The filter pattern to use for the CloudWatch log subscription filter. Use this to filter which logs are sent to Coralogix. An empty string matches all log events. For filter pattern syntax, see [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html). | `string` | `""` | no |
 
 > [!NOTE]
 > The `log_group` variable will get a list of log groups and then add them to the Lambda as triggers, each log group will also add permission to the Lambda, in some cases when there are a lot of log groups this will cause an error because the code 

--- a/modules/coralogix-aws-shipper/main.tf
+++ b/modules/coralogix-aws-shipper/main.tf
@@ -245,25 +245,25 @@ module "lambda" {
   vpc_security_group_ids         = var.security_group_ids
   dead_letter_target_arn         = var.enable_dlq ? aws_sqs_queue.DLQ[0].arn : null
   environment_variables = {
-    CORALOGIX_ENDPOINT = var.custom_domain != "" ? "https://ingress.${var.custom_domain}" : var.subnet_ids == null ? "https://ingress.${lookup(module.locals[each.key].coralogix_domains, var.coralogix_region, "EU1")}" : "https://ingress.private.${lookup(module.locals[each.key].coralogix_domains, var.coralogix_region, "EU1")}"
-    INTEGRATION_TYPE   = each.value.integration_type
-    RUST_LOG           = var.log_level
-    CORALOGIX_API_KEY  = !local.api_key_is_arn && (each.value.store_api_key_in_secrets_manager == null || each.value.store_api_key_in_secrets_manager == true) ? aws_secretsmanager_secret.coralogix_secret[each.key].arn : each.value.api_key
-    APP_NAME           = each.value.application_name
-    SUB_NAME           = each.value.subsystem_name
-    NEWLINE_PATTERN    = each.value.newline_pattern != null ? each.value.newline_pattern : null
-    BLOCKING_PATTERN   = var.blocking_pattern
-    SAMPLING           = tostring(var.sampling_rate)
-    ADD_METADATA       = var.add_metadata
-    CUSTOM_METADATA    = var.custom_metadata
-    CUSTOM_CSV_HEADER  = var.custom_csv_header
-    DLQ_ARN            = var.enable_dlq ? aws_sqs_queue.DLQ[0].arn : null
-    DLQ_RETRY_LIMIT    = var.enable_dlq ? var.dlq_retry_limit : null
-    DLQ_S3_BUCKET      = var.enable_dlq ? var.dlq_s3_bucket : null
-    DLQ_URL            = var.enable_dlq ? aws_sqs_queue.DLQ[0].url : null
-    ASSUME_ROLE_ARN    = var.lambda_assume_role_arn
-    TELEMETRY_MODE     = var.telemetry_mode
-    BATCH_METRICS      = var.telemetry_mode == "metrics" && var.batch_metrics ? "1" : null
+    CORALOGIX_ENDPOINT     = var.custom_domain != "" ? "https://ingress.${var.custom_domain}" : var.subnet_ids == null ? "https://ingress.${lookup(module.locals[each.key].coralogix_domains, var.coralogix_region, "EU1")}" : "https://ingress.private.${lookup(module.locals[each.key].coralogix_domains, var.coralogix_region, "EU1")}"
+    INTEGRATION_TYPE       = each.value.integration_type
+    RUST_LOG               = var.log_level
+    CORALOGIX_API_KEY      = !local.api_key_is_arn && (each.value.store_api_key_in_secrets_manager == null || each.value.store_api_key_in_secrets_manager == true) ? aws_secretsmanager_secret.coralogix_secret[each.key].arn : each.value.api_key
+    APP_NAME               = each.value.application_name
+    SUB_NAME               = each.value.subsystem_name
+    NEWLINE_PATTERN        = each.value.newline_pattern != null ? each.value.newline_pattern : null
+    BLOCKING_PATTERN       = var.blocking_pattern
+    SAMPLING               = tostring(var.sampling_rate)
+    ADD_METADATA           = var.add_metadata
+    CUSTOM_METADATA        = var.custom_metadata
+    CUSTOM_CSV_HEADER      = var.custom_csv_header
+    DLQ_ARN                = var.enable_dlq ? aws_sqs_queue.DLQ[0].arn : null
+    DLQ_RETRY_LIMIT        = var.enable_dlq ? var.dlq_retry_limit : null
+    DLQ_S3_BUCKET          = var.enable_dlq ? var.dlq_s3_bucket : null
+    DLQ_URL                = var.enable_dlq ? aws_sqs_queue.DLQ[0].url : null
+    ASSUME_ROLE_ARN        = var.lambda_assume_role_arn
+    TELEMETRY_MODE         = var.telemetry_mode
+    BATCH_METRICS          = var.telemetry_mode == "metrics" && var.batch_metrics ? "1" : null
     METRICS_BATCH_MAX_SIZE = var.telemetry_mode == "metrics" && var.batch_metrics ? tostring(var.metrics_batch_max_size) : null
   }
   s3_existing_package = {

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -128,6 +128,12 @@ variable "log_group_prefix" {
   default     = null
 }
 
+variable "log_group_filter_pattern" {
+  description = "The filter pattern to use for the CloudWatch log subscription filter. Use this to filter which logs are sent to Coralogix. An empty string matches all log events."
+  type        = string
+  default     = ""
+}
+
 # kinesis variables
 
 variable "kinesis_stream_name" {


### PR DESCRIPTION
## Summary

- Added `log_group_filter_pattern` variable to the `coralogix-aws-shipper` module to allow customers to specify a filter pattern for CloudWatch log subscription filters
- This enables filtering which logs are sent to Coralogix instead of forwarding all log events by default
- Updated README documentation with the new variable
- Added CHANGELOG entry for v3.15.1

## Problem

Customers using Terraform to deploy Lambda functions that ingest data from CloudWatch were unable to set subscription filter parameters. The `filter_pattern` was hardcoded to an empty string, meaning all logs were forwarded regardless of customer requirements.

## Solution

Exposed the `filter_pattern` as a configurable variable with a default of `""` (empty string) to maintain backward compatibility while allowing customers to specify their own filter patterns.

## Usage Example

```terraform
module "coralogix_shipper" {
  source = "coralogix/aws/coralogix//modules/coralogix-aws-shipper"
  
  integration_type         = "CloudWatch"
  log_groups               = ["my-log-group"]
  log_group_filter_pattern = "ERROR"  # Only forward logs containing "ERROR"
}
```

## Test plan

- [ ] Verify Terraform plan shows the new variable is accepted
- [ ] Verify subscription filter is created with the specified pattern
- [ ] Verify backward compatibility (empty string default still works)

Resolves: CDS-2663