### PR TITLE
feat: Allow control of content-encoding via variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.21.0
+#### **firehose-logs**
+### 💡 Enhancements 💡
+- Allow control of content-encoding via variable.
+
 ## v3.20.0
 #### **firehose-metrics**
 ### 💡 Enhancements 💡
@@ -51,11 +56,6 @@
 ### 💡 Enhancements 💡
 - Added `execution_role_arn` and `create_execution_role` variables for providing a custom Lambda execution role without breaking Terraform's plan-time dependency graph.
 - Deprecated `execution_role_name` in favor of `execution_role_arn`.
-
-## v3.17.0
-#### **firehose-logs**
-### 💡 Enhancements 💡
-- Allow control of content-encoding via variable.
 
 ## v3.16.0
 #### **ecs-ec2**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
 - Added `execution_role_arn` and `create_execution_role` variables for providing a custom Lambda execution role without breaking Terraform's plan-time dependency graph.
 - Deprecated `execution_role_name` in favor of `execution_role_arn`.
 
+## v3.17.0
+#### **firehose-logs**
+### 💡 Enhancements 💡
+- Allow control of content-encoding via variable.
+
 ## v3.16.0
 #### **ecs-ec2**
 ### 🔒 Security Enhancements 🔒

--- a/examples/firehose-logs/variables.tf
+++ b/examples/firehose-logs/variables.tf
@@ -75,3 +75,14 @@ variable "server_side_encryption" {
     key_type = "AWS_OWNED_CMK"
   }
 }
+
+variable "content_encoding" {
+  description = "Content encoding for the firehose delivery stream"
+  type        = string
+  default     = "GZIP"
+
+  validation {
+    condition     = contains(["NONE", "GZIP"], var.content_encoding)
+    error_message = "Allowed values are NONE and GZIP"
+  }
+}

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -105,6 +105,7 @@ It is possible to pass a custom coralogix domain by using the `custom_domain` va
 | <a name="input_user_supplied_tags"></a> [user_supplied_tags](#input\_user_supplied_tags) | Tags supplied by the user to populate to all generated resources | `map(string)` | n/a | no |
 | <a name="input_override_default_tags"></a> [override_default_tags](#input\_override_default_tags) | Override and remove the default tags by setting to true | `bool` | `false` | no |
 | <a name="s3_enable_secure_transport"></a> [s3\_enable\_secure\_transport](variables.tf#L105) | Disable if you dont want bucket policy that complies with s3-bucket-ssl-requests-only rule | `bool` | `true` | no |
+| <a name="content_encoding"></a> [content\_encoding](variables.tf#L129) | Set encoding of data in firehose to GZIP or NONE | `string` | `GZIP` | no |
 
 ## Coralgoix regions
 

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -250,7 +250,7 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_logs" {
     }
 
     request_configuration {
-      content_encoding = "GZIP"
+      content_encoding = var.content_encoding
 
       dynamic "common_attributes" {
         for_each = var.integration_type_logs == null ? [] : [1]

--- a/modules/firehose-logs/variables.tf
+++ b/modules/firehose-logs/variables.tf
@@ -125,3 +125,14 @@ variable "server_side_encryption" {
     error_message = "Valid values for key_type are AWS_OWNED_CMK and CUSTOMER_MANAGED_CMK."
   }
 }
+
+variable "content_encoding" {
+  description = "Content encoding for the firehose delivery stream"
+  type        = string
+  default     = "GZIP"
+
+  validation {
+    condition     = contains(["NONE", "GZIP"], var.content_encoding)
+    error_message = "Allowed values are NONE and GZIP"
+  }
+}


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
The firehose-logs module would create a data firehose stream but the content-encoding option was set to GZIP by default. This actually resulted in an error from Firehose returning a 413 and invalid payload from the coralogix API as it was unable to identify the gzipped data.
This PR lets user disable the encoding if required, but the default option is set to GZIP so it should be fully backward compatible.
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #297

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)