### PR TITLE
fix: Use merge for IAM policy statements for resource-metadata-sqs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,7 @@ jobs:
     if: github.repository_owner == 'coralogix'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Fetch tags
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
-
+      
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16 # v5.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,12 @@ jobs:
     if: github.repository_owner == 'coralogix'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@9cc899c47e6841430bbaedb43de1560a568dfd16 # v5.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.19.3
+#### **resource-metadata-sqs**
+### 🐛 Bug Fix 🔧
+- `policy_statements` was updated so that optional statements are only added when needed, instead of being set to null when disabled. 
+
 ## v3.19.2
 #### **firehose-metrics**
 ### 🔧 Maintenance 🔧

--- a/modules/resource-metadata-sqs/main.tf
+++ b/modules/resource-metadata-sqs/main.tf
@@ -127,57 +127,56 @@ module "collector_lambda" {
   }
 
   attach_policy_statements = true
-  policy_statements = {
-    ec2 = {
-      effect = "Allow"
-      actions = [
-        "ec2:DescribeInstances"
-      ]
-      resources = ["*"]
-    }
-    lambda = {
-      effect = "Allow"
-      actions = [
-        "lambda:ListFunctions"
-      ]
-      resources = ["*"]
-    }
-    tags = {
-      effect = "Allow"
-      actions = [
-        "tag:GetResources"
-      ]
-      resources = ["*"]
-    }
-    sqs = {
-      effect = "Allow"
-      actions = [
-        "sqs:SendMessage"
-      ]
-      resources = [aws_sqs_queue.metadata_queue.arn]
-    }
-    assume_role = var.crossaccount_mode == "StaticIAM" ? {
-      effect = "Allow"
-      actions = [
-        "sts:AssumeRole"
-      ]
-      resources = ["arn:aws:iam::*:role/${var.crossaccount_iam_role_name}"]
-    } : null
-    config = var.crossaccount_mode == "Config" ? {
-      effect = "Allow"
-      actions = [
-        "config:SelectAggregateResourceConfig"
-      ]
-      resources = ["*"]
-    } : null
-    assume_config_role = length(var.crossaccount_config_assume_role) > 0 ? {
-      effect = "Allow"
-      actions = [
-        "sts:AssumeRole"
-      ]
-      resources = [var.crossaccount_config_assume_role]
-    } : null
-  }
+  policy_statements = merge(
+    {
+      ec2 = {
+        effect = "Allow"
+        actions = [
+          "ec2:DescribeInstances"
+        ]
+        resources = ["*"]
+      }
+      lambda = {
+        effect = "Allow"
+        actions = [
+          "lambda:ListFunctions"
+        ]
+        resources = ["*"]
+      }
+      tags = {
+        effect = "Allow"
+        actions = [
+          "tag:GetResources"
+        ]
+        resources = ["*"]
+      }
+      sqs = {
+        effect = "Allow"
+        actions = [
+          "sqs:SendMessage"
+        ]
+        resources = [aws_sqs_queue.metadata_queue.arn]
+      }
+    },
+    var.crossaccount_mode == "StaticIAM" ? {
+      assume_role = {
+        effect = "Allow"
+        actions = [
+          "sts:AssumeRole"
+        ]
+        resources = ["arn:aws:iam::*:role/${var.crossaccount_iam_role_name}"]
+      }
+    } : {},
+    var.crossaccount_mode == "Config" ? {
+      config = {
+        effect = "Allow"
+        actions = [
+          "config:SelectAggregateResourceConfig"
+        ]
+        resources = ["*"]
+      }
+    } : {}
+  )
 
   allowed_triggers = {
     EventBridge = {
@@ -223,44 +222,48 @@ module "generator_lambda" {
   }
 
   attach_policy_statements = true
-  policy_statements = {
-    ec2 = {
-      effect = "Allow"
-      actions = [
-        "ec2:DescribeInstances"
-      ]
-      resources = ["*"]
-    }
-    lambda = {
-      effect = "Allow"
-      actions = [
-        "lambda:ListVersionsByFunction",
-        "lambda:GetFunctionConfiguration",
-        "lambda:GetFunctionConcurrency",
-        "lambda:ListTags",
-        "lambda:ListAliases",
-        "lambda:ListEventSourceMappings",
-        "lambda:GetPolicy"
-      ]
-      resources = ["*"]
-    }
-    sqs = {
-      effect = "Allow"
-      actions = [
-        "sqs:ReceiveMessage",
-        "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes"
-      ]
-      resources = [aws_sqs_queue.metadata_queue.arn]
-    }
-    assume_role = var.crossaccount_mode == "Disabled" ? null : {
-      effect = "Allow"
-      actions = [
-        "sts:AssumeRole"
-      ]
-      resources = ["arn:aws:iam::*:role/${var.crossaccount_iam_role_name}"]
-    }
-  }
+  policy_statements = merge(
+    {
+      ec2 = {
+        effect = "Allow"
+        actions = [
+          "ec2:DescribeInstances"
+        ]
+        resources = ["*"]
+      }
+      lambda = {
+        effect = "Allow"
+        actions = [
+          "lambda:ListVersionsByFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetFunctionConcurrency",
+          "lambda:ListTags",
+          "lambda:ListAliases",
+          "lambda:ListEventSourceMappings",
+          "lambda:GetPolicy"
+        ]
+        resources = ["*"]
+      }
+      sqs = {
+        effect = "Allow"
+        actions = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes"
+        ]
+        resources = [aws_sqs_queue.metadata_queue.arn]
+      }
+    },
+    var.crossaccount_mode != "Disabled" ? {
+      assume_role = {
+        effect = "Allow"
+        actions = [
+          "sts:AssumeRole"
+        ]
+        resources = ["arn:aws:iam::*:role/${var.crossaccount_iam_role_name}"]
+      }
+    } : {}
+  )
 
   allowed_triggers = {
     SQS = {
@@ -319,54 +322,58 @@ module "generator_lambda_sm" {
   }
 
   attach_policy_statements = true
-  policy_statements = {
-    ec2 = {
-      effect = "Allow"
-      actions = [
-        "ec2:DescribeInstances"
-      ]
-      resources = ["*"]
-    }
-    lambda = {
-      effect = "Allow"
-      actions = [
-        "lambda:ListVersionsByFunction",
-        "lambda:GetFunctionConfiguration",
-        "lambda:GetFunctionConcurrency",
-        "lambda:ListTags",
-        "lambda:ListAliases",
-        "lambda:ListEventSourceMappings",
-        "lambda:GetPolicy"
-      ]
-      resources = ["*"]
-    }
-    sqs = {
-      effect = "Allow"
-      actions = [
-        "sqs:ReceiveMessage",
-        "sqs:DeleteMessage",
-        "sqs:GetQueueAttributes"
-      ]
-      resources = [aws_sqs_queue.metadata_queue.arn]
-    }
-    assume_role = var.crossaccount_mode == "Disabled" ? null : {
-      effect = "Allow"
-      actions = [
-        "sts:AssumeRole"
-      ]
-      resources = ["arn:aws:iam::*:role/${var.crossaccount_iam_role_name}"]
-    }
-    secrets = {
-      effect = "Allow"
-      actions = [
-        "secretsmanager:DescribeSecret",
-        "secretsmanager:GetSecretValue",
-        "secretsmanager:PutSecretValue",
-        "secretsmanager:UpdateSecret"
-      ]
-      resources = ["*"]
-    }
-  }
+  policy_statements = merge(
+    {
+      ec2 = {
+        effect = "Allow"
+        actions = [
+          "ec2:DescribeInstances"
+        ]
+        resources = ["*"]
+      }
+      lambda = {
+        effect = "Allow"
+        actions = [
+          "lambda:ListVersionsByFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetFunctionConcurrency",
+          "lambda:ListTags",
+          "lambda:ListAliases",
+          "lambda:ListEventSourceMappings",
+          "lambda:GetPolicy"
+        ]
+        resources = ["*"]
+      }
+      sqs = {
+        effect = "Allow"
+        actions = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes"
+        ]
+        resources = [aws_sqs_queue.metadata_queue.arn]
+      }
+      secrets = {
+        effect = "Allow"
+        actions = [
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecret"
+        ]
+        resources = ["*"]
+      }
+    },
+    var.crossaccount_mode != "Disabled" ? {
+      assume_role = {
+        effect = "Allow"
+        actions = [
+          "sts:AssumeRole"
+        ]
+        resources = ["arn:aws:iam::*:role/${var.crossaccount_iam_role_name}"]
+      }
+    } : {}
+  )
 
   allowed_triggers = {
     SQS = {


### PR DESCRIPTION
# Description

Fixes error in `resource-metadata-sqs` module: `Policy statement must contain actions`. 

`policy_statements` was updated so that optional statements are only added when needed, instead of being set to null when disabled. That way the Lambda module never sees a null statement.

# How Has This Been Tested?

Ran locally.
