### PR TITLE
fix: resolve 2 bugs in resource-metadata-sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 #### **resource-metadata-sqs**
 ### 🐛 Bug Fix 🔧
 - Add missing env var `EC2_CHUNK_SIZE`
-- Add inline policy to assume cross-config AWS Config role
+- Add inline policy to assume cross-account AWS Config role
 
 ## v3.19.3
 #### **resource-metadata-sqs**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.19.4
+#### **resource-metadata-sqs**
+### 🐛 Bug Fix 🔧
+- Add missing env var `EC2_CHUNK_SIZE`
+
 ## v3.19.3
 #### **resource-metadata-sqs**
 ### 🐛 Bug Fix 🔧

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### **resource-metadata-sqs**
 ### 🐛 Bug Fix 🔧
 - Add missing env var `EC2_CHUNK_SIZE`
+- Add inline policy to assume cross-config AWS Config role
 
 ## v3.19.3
 #### **resource-metadata-sqs**

--- a/modules/resource-metadata-sqs/main.tf
+++ b/modules/resource-metadata-sqs/main.tf
@@ -119,6 +119,7 @@ module "collector_lambda" {
     IS_EC2_RESOURCE_TYPE_EXCLUDED        = var.excluded_ec2_resource_type
     IS_LAMBDA_RESOURCE_TYPE_EXCLUDED     = var.excluded_lambda_resource_type
     METADATA_QUEUE_URL                   = aws_sqs_queue.metadata_queue.url
+    EC2_CHUNK_SIZE                       = tostring(var.ec2_chunk_size)
   }
 
   s3_existing_package = {
@@ -214,6 +215,7 @@ module "generator_lambda" {
     RESOURCE_TTL_MINUTES         = var.resource_ttl_minutes
     AWS_RETRY_MODE               = "adaptive"
     AWS_MAX_ATTEMPTS             = 10
+    EC2_CHUNK_SIZE               = tostring(var.ec2_chunk_size)
   }
 
   s3_existing_package = {
@@ -314,6 +316,7 @@ module "generator_lambda_sm" {
     RESOURCE_TTL_MINUTES         = var.resource_ttl_minutes
     AWS_RETRY_MODE               = "adaptive"
     AWS_MAX_ATTEMPTS             = 10
+    EC2_CHUNK_SIZE               = tostring(var.ec2_chunk_size)
   }
 
   s3_existing_package = {

--- a/modules/resource-metadata-sqs/main.tf
+++ b/modules/resource-metadata-sqs/main.tf
@@ -176,6 +176,15 @@ module "collector_lambda" {
         ]
         resources = ["*"]
       }
+    } : {},
+    var.crossaccount_mode == "Config" && length(var.crossaccount_config_assume_role) > 0 ? {
+      assume_config_role = {
+        effect = "Allow"
+        actions = [
+          "sts:AssumeRole"
+        ]
+        resources = [var.crossaccount_config_assume_role]
+      }
     } : {}
   )
 

--- a/modules/resource-metadata-sqs/variables.tf
+++ b/modules/resource-metadata-sqs/variables.tf
@@ -176,6 +176,16 @@ variable "excluded_ec2_resource_type" {
   default     = false
 }
 
+variable "ec2_chunk_size" {
+  description = "Number of EC2 instances to process per batch when collecting metadata. Required by the collector Lambda."
+  type        = number
+  default     = 25
+  validation {
+    condition     = var.ec2_chunk_size >= 10 && var.ec2_chunk_size <= 40
+    error_message = "EC2 chunk size must be between 10 and 40."
+  }
+}
+
 variable "excluded_lambda_resource_type" {
   description = "Is Lambda Resource Type Excluded?"
   type        = bool


### PR DESCRIPTION
# Description

This will:

1. add missing `EC2_CHUNK_SIZE` env variable, required to run the collector Lambda function.
2. add inline policy to assume cross-account AWS Config role when it's set

# How Has This Been Tested?

Ran locally.
