### PR TITLE
fix: URLs for eventbridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.19.5
+#### **eventbridge**
+### 🐛 Bug Fix 🔧
+- Updated endpoint format from the legacy `https://aws-events.<domain>/aws/event` to the current Coralogix standard `https://ingress.<domain>/aws/event-bridge` for all regions.
+- Fixed `custom_url` variable being silently ignored when `coralogix_region = "Custom"`. The `endpoint_url` local now correctly uses `custom_url` for custom region deployments instead of falling back to `EU1`.
+
 ## v3.19.4
 #### **resource-metadata-sqs**
 ### 🐛 Bug Fix 🔧

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -48,6 +48,7 @@ The coralogix region variable accepts one of the following regions:
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -30,33 +30,33 @@ The coralogix region variable accepts one of the following regions:
 * US2
 * Custom
 
-*** All of the regions must be written with lower-case letters. 
-
 ### Endpoints
 
-| Region    | Logs Endpoint
-|-----------|-----------------------------------------------------------------|
-| EU1       | `https://aws-events.coralogix.com/aws/event`                |
-| EU2       | `https://aws-events.eu2.coralogix.com/aws/event`           |
-| AP1       | `https://aws-events.ap1.coralogix.com/aws/event`             |
-| AP2       | `https://aws-events.ap2.coralogix.com/aws/event`             |
-| AP3       | `https://aws-events.ap3.coralogix.com/aws/event`           |
-| US1       | `https://aws-events.us1.coralogix.com/aws/event`                |
-| US2       | `https://aws-events.us2.coralogix.com/aws/event`          |
-| Custom    | `https://aws-events.<custom_domain>/aws/event`             |
+| Region    | Logs Endpoint                                                          |
+|-----------|------------------------------------------------------------------------|
+| EU1       | `https://ingress.eu1.coralogix.com/aws/event-bridge`                  |
+| EU2       | `https://ingress.eu2.coralogix.com/aws/event-bridge`                  |
+| AP1       | `https://ingress.ap1.coralogix.com/aws/event-bridge`                  |
+| AP2       | `https://ingress.ap2.coralogix.com/aws/event-bridge`                  |
+| AP3       | `https://ingress.ap3.coralogix.com/aws/event-bridge`                  |
+| US1       | `https://ingress.us1.coralogix.com/aws/event-bridge`                  |
+| US2       | `https://ingress.us2.coralogix.com/aws/event-bridge`                  |
+| Custom    | `https://ingress.<custom_domain>/aws/event-bridge`                    |
+
+> **Note for Custom domains**: If your Coralogix team URL uses a cluster-specific domain (e.g. `cx498.coralogix.com`), set `coralogix_region = "Custom"` and `custom_url = "<your-cluster>.coralogix.com"`. This applies to US2 accounts whose team hostname is `team.app.cx498.coralogix.com` — use `custom_url = "cx498.coralogix.com"` instead of `coralogix_region = "US2"`.
 
 
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.17.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.17.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Resources
 
@@ -77,7 +77,7 @@ The coralogix region variable accepts one of the following regions:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_application_name"></a> [application\_name](#input\_application\_name) | Coralogix application name | `string` | n/a | yes |
-| <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | Coralogix account region: us, us2, singapore, ireland, india, stockholm [in lower-case letters] | `any` | n/a | yes |
+| <a name="input_coralogix_region"></a> [coralogix\_region](#input\_coralogix\_region) | Coralogix account region. Accepted values: `EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`, `Custom` | `string` | n/a | yes |
 | <a name="input_custom_url"></a> [custom_url](#input\_custom\_url) | Custom coralogix url | `string` | `null` | no |
 | <a name="input_eventbridge_stream"></a> [eventbridge\_stream](#input\_eventbridge\_stream) | AWS eventbridge delivery stream name | `string` | n/a | yes |
 | <a name="input_private_key"></a> [private\_key](#input\_private\_key) | Your Coralogix private key | `string` | n/a | yes |

--- a/modules/eventbridge/README.md
+++ b/modules/eventbridge/README.md
@@ -43,8 +43,6 @@ The coralogix region variable accepts one of the following regions:
 | US2       | `https://ingress.us2.coralogix.com/aws/event-bridge`                  |
 | Custom    | `https://ingress.<custom_domain>/aws/event-bridge`                    |
 
-> **Note for Custom domains**: If your Coralogix team URL uses a cluster-specific domain (e.g. `cx498.coralogix.com`), set `coralogix_region = "Custom"` and `custom_url = "<your-cluster>.coralogix.com"`. This applies to US2 accounts whose team hostname is `team.app.cx498.coralogix.com` — use `custom_url = "cx498.coralogix.com"` instead of `coralogix_region = "US2"`.
-
 
 ## Requirements
 

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -15,7 +15,8 @@ module "locals" {
 }
 
 locals {
-  endpoint_url = var.coralogix_region == "Custom" ? "https://ingress.${var.custom_url}/aws/event-bridge" : "https://ingress.${lookup(module.locals.coralogix_domains, var.coralogix_region, "eu1.coralogix.com")}/aws/event-bridge"
+  validate_custom_url = var.coralogix_region == "Custom" && (var.custom_url == null || var.custom_url == "") ? tobool("custom_url must be set when coralogix_region is 'Custom'") : true
+  endpoint_url        = var.coralogix_region == "Custom" ? "https://ingress.${var.custom_url}/aws/event-bridge" : "https://ingress.${lookup(module.locals.coralogix_domains, var.coralogix_region, "eu1.coralogix.com")}/aws/event-bridge"
   tags = {
     terraform-module         = "eventbridge-to-coralogix"
     terraform-module-version = "v0.0.3"

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.9"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -15,11 +16,10 @@ module "locals" {
 }
 
 locals {
-  validate_custom_url = var.coralogix_region == "Custom" && (var.custom_url == null || var.custom_url == "") ? tobool("custom_url must be set when coralogix_region is 'Custom'") : true
-  endpoint_url        = var.coralogix_region == "Custom" ? "https://ingress.${var.custom_url}/aws/event-bridge" : "https://ingress.${lookup(module.locals.coralogix_domains, var.coralogix_region, "eu1.coralogix.com")}/aws/event-bridge"
+  endpoint_url = var.coralogix_region == "Custom" ? "https://ingress.${var.custom_url}/aws/event-bridge" : "https://ingress.${lookup(module.locals.coralogix_domains, var.coralogix_region, "eu1.coralogix.com")}/aws/event-bridge"
   tags = {
     terraform-module         = "eventbridge-to-coralogix"
-    terraform-module-version = "v0.0.3"
+    terraform-module-version = "v0.0.4"
     managed-by               = "coralogix-terraform"
   }
   application_name = var.application_name == null ? "coralogix-${var.eventbridge_stream}" : var.application_name

--- a/modules/eventbridge/main.tf
+++ b/modules/eventbridge/main.tf
@@ -15,7 +15,7 @@ module "locals" {
 }
 
 locals {
-  endpoint_url = "https://aws-events.${lookup(module.locals.coralogix_domains, var.coralogix_region, "EU1")}/aws/event"
+  endpoint_url = var.coralogix_region == "Custom" ? "https://ingress.${var.custom_url}/aws/event-bridge" : "https://ingress.${lookup(module.locals.coralogix_domains, var.coralogix_region, "eu1.coralogix.com")}/aws/event-bridge"
   tags = {
     terraform-module         = "eventbridge-to-coralogix"
     terraform-module-version = "v0.0.3"

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -24,7 +24,7 @@ variable "coralogix_region" {
 }
 
 variable "custom_url" {
-  description = "Custom Coralogix domain (e.g. 'cx498.coralogix.com'). Required when coralogix_region is set to 'Custom'."
+  description = "Custom Coralogix domain. Required when coralogix_region is set to 'Custom'."
   type        = string
   default     = null
   validation {

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -27,6 +27,10 @@ variable "custom_url" {
   description = "Custom Coralogix domain (e.g. 'cx498.coralogix.com'). Required when coralogix_region is set to 'Custom'."
   type        = string
   default     = null
+  validation {
+    condition     = var.coralogix_region != "Custom" || (var.custom_url != null && var.custom_url != "")
+    error_message = "custom_url must be set when coralogix_region is 'Custom'."
+  }
 }
 
 variable "sources" {

--- a/modules/eventbridge/variables.tf
+++ b/modules/eventbridge/variables.tf
@@ -24,9 +24,9 @@ variable "coralogix_region" {
 }
 
 variable "custom_url" {
-  description = "Custom coralogix url"
+  description = "Custom Coralogix domain (e.g. 'cx498.coralogix.com'). Required when coralogix_region is set to 'Custom'."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "sources" {


### PR DESCRIPTION
# Description

1. **Wrong endpoint format** - The module was using the legacy
   `https://aws-events.<domain>/aws/event` format, which does not resolve
   correctly for all regions (e.g. `aws-events.us2.coralogix.com` is not a
   valid host). The current Coralogix-documented format is
   `https://ingress.<domain>/aws/event-bridge`.

2. **`Custom` region was silently broken** - When `coralogix_region = "Custom"`,
   the `lookup()` call had no match in the `coralogix_domains` map and fell back
   to `EU1`, meaning `custom_url` was completely ignored and logs were sent to
   the wrong region.

3. **README was outdated** -  Endpoints table used the old format, EU1 entry was
   wrong, the provider version was stale (`~> 4.17.1`), and the region input was
   described as requiring lowercase-only values.

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)