### PR TITLE
fix(coralogix-aws-shipper): add create_sqs_queue_policy flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.3.2
+
+#### **coralogix-aws-shipper**
+### 💡 Enhancements 💡
+- Added `create_sqs_queue_policy` variable to allow users to preserve existing SQS queue policies when using SQS-based integrations (S3, CloudTrail, VpcFlow, CloudFront, S3Csv). Set to `false` to prevent the module from overwriting custom SQS queue policies.
+
 ## v4.3.1
 
 #### **ecs-ec2-windows**

--- a/examples/coralogix-aws-shipper/README.md
+++ b/examples/coralogix-aws-shipper/README.md
@@ -311,6 +311,22 @@ module "coralogix-shipper-Sqs" {
 }
 ```
 
+### SQS with Custom SQS Policy
+```bash
+module "coralogix-shipper-sqs-custom-policy" {
+  source = "coralogix/aws/coralogix//modules/coralogix-aws-shipper"
+
+  coralogix_region        = "EU1"
+  integration_type        = "S3"
+  api_key                 = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
+  application_name        = "s3-sqs-custom-policy"
+  subsystem_name          = "logs"
+  s3_bucket_name          = "test-bucket-name"
+  sqs_name                = "your-existing-sqs-queue"
+  create_sqs_queue_policy = false  # Preserve existing SQS queue policy
+}
+```
+
 <!-- /example -->
 
 <!-- example id="SNS-integration" -->
@@ -426,6 +442,48 @@ module "coralogix-shipper-custom-policy" {
       },
       "Action": "SNS:Publish",
       "Resource": "arn:aws:sns:REGION:ACCOUNT-ID:TOPIC-NAME",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:s3:::YOUR-S3-BUCKET-NAME"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Custom SQS Queue Policy Management
+
+When using SQS-based integrations (S3, CloudTrail), the module creates a restrictive SQS queue policy by default. If you want to preserve your existing SQS queue policies, set `create_sqs_queue_policy = false`:
+
+```bash
+module "coralogix-shipper-custom-sqs-policy" {
+  source = "coralogix/aws/coralogix//modules/coralogix-aws-shipper"
+
+  coralogix_region        = "EU1"
+  integration_type        = "S3"
+  api_key                 = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXX"
+  application_name        = "custom-sqs-policy-example"
+  subsystem_name          = "logs"
+  s3_bucket_name          = "test-bucket-name"
+  sqs_name                = "your-existing-sqs-queue"
+  create_sqs_queue_policy = false  # Preserve existing SQS queue policy
+}
+```
+
+**Important**: When using `create_sqs_queue_policy = false`, ensure your SQS queue policy includes the required S3 service permission:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Action": "SQS:SendMessage",
+      "Resource": "arn:aws:sqs:REGION:ACCOUNT-ID:QUEUE-NAME",
       "Condition": {
         "ArnLike": {
           "aws:SourceArn": "arn:aws:s3:::YOUR-S3-BUCKET-NAME"

--- a/examples/coralogix-aws-shipper/coralogix-aws-shipper.tf
+++ b/examples/coralogix-aws-shipper/coralogix-aws-shipper.tf
@@ -11,4 +11,5 @@ module "coralogix-shipper" {
   s3_bucket_name   = "test-bucket-name"
   integration_type = "S3"
   # create_sns_topic_policy = true  # Default: module manages SNS topic policy
+  # create_sqs_queue_policy = true  # Default: module manages SQS queue policy
 }

--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -196,6 +196,12 @@ variable "sqs_name" {
   default     = null
 }
 
+variable "create_sqs_queue_policy" {
+  description = "Whether to create and manage the SQS queue policy. Set to false if you want to manage the policy yourself and preserve existing permissions. See README for required permissions when using custom policy."
+  type        = bool
+  default     = true
+}
+
 # sns variables
 
 variable "sns_topic_name" {

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -132,6 +132,7 @@ If you're deploying multiple integrations through the same S3 bucket, you'll nee
 | Name | Description | Type | Default | Required | 
 |------|-------------|------|---------|:--------:|
 | <a name="input_sqs_name"></a> [sqs_name](#input\_sqs\_name) | The name of the SQS queue to which you want to subscribe for retrieving messages.| `string` |  n/a | yes |
+| <a name="input_create_sqs_queue_policy"></a> [create_sqs_queue_policy](#input\_create\_sqs\_queue\_policy) | Whether to create and manage the SQS queue policy. Set to false if you want to manage the policy yourself and preserve existing permissions. | `bool` | `true` | no |
 
 <!-- /description -->
 
@@ -498,6 +499,47 @@ When `create_sns_topic_policy = false`, include this permission in your SNS topi
 ```
 
 **Note**: This only applies to S3-based integrations (S3, CloudTrail, VpcFlow, CloudFront, S3Csv). Direct SNS integration (`integration_type = "Sns"`) does not create SNS topic policies.
+
+## Custom SQS Queue Policy Management
+
+Set `create_sqs_queue_policy = false` to preserve existing SQS queue policies:
+
+```hcl
+module "coralogix_shipper" {
+  source = "coralogix/coralogix-aws-shipper/aws"
+
+  create_sqs_queue_policy = false
+  sqs_name               = "your-existing-sqs-queue"
+  # ... other configuration
+}
+```
+
+### Required Permissions
+
+When `create_sqs_queue_policy = false`, include this permission in your SQS queue policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Action": "SQS:SendMessage",
+      "Resource": "arn:aws:sqs:REGION:ACCOUNT-ID:QUEUE-NAME",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:s3:::YOUR-S3-BUCKET-NAME"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Note**: This only applies to S3-based integrations (S3, CloudTrail, VpcFlow, CloudFront, S3Csv) when using SQS.
 
 ## Outputs
 

--- a/modules/coralogix-aws-shipper/Sqs.tf
+++ b/modules/coralogix-aws-shipper/Sqs.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_event_source_mapping" "sqs" {
 }
 
 resource "aws_sqs_queue_policy" "sqs_policy" {
-  count     = local.is_s3_integration && var.sqs_name != null ? 1 : 0
+  count     = var.create_sqs_queue_policy && local.is_s3_integration && var.sqs_name != null ? 1 : 0
   queue_url = data.aws_sqs_queue.name[count.index].id
   policy    = data.aws_iam_policy_document.topic[count.index].json
 }

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -246,6 +246,12 @@ variable "create_sns_topic_policy" {
   default     = true
 }
 
+variable "create_sqs_queue_policy" {
+  description = "Whether to create and manage the SQS queue policy. Set to false if you want to manage the policy yourself and preserve existing permissions. See README for required permissions when using custom policy."
+  type        = bool
+  default     = true
+}
+
 # vpc variables
 
 variable "subnet_ids" {

--- a/modules/provisioning/msk-data-stream/main.tf
+++ b/modules/provisioning/msk-data-stream/main.tf
@@ -90,7 +90,7 @@ resource "aws_security_group" "sg" {
     from_port   = 9198
     to_port     = 9198
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.coralogix_cidr_blocks != null ? var.coralogix_cidr_blocks : lookup(var.coralogix_cidr_mapping, var.aws_region, ["0.0.0.0/0"])
   }
 
   egress {

--- a/modules/provisioning/msk-data-stream/variables.tf
+++ b/modules/provisioning/msk-data-stream/variables.tf
@@ -57,3 +57,23 @@ variable "coraloigx_roles_arn_mapping" {
     "custom"         = ""
   }
 }
+
+variable "coralogix_cidr_blocks" {
+  type        = list(string)
+  description = "The CIDR blocks to allow ingress from Coralogix to the MSK cluster. If not set, defaults to the Coralogix CIDR for the selected region."
+  default     = null
+}
+
+variable "coralogix_cidr_mapping" {
+  type = map(list(string))
+  default = {
+    "eu-west-1"      = ["18.97.198.64/26"]
+    "eu-north-1"     = ["18.99.99.64/26"]
+    "ap-southeast-1" = ["18.99.41.64/26"]
+    "ap-southeast-3" = ["18.98.97.0/26"]
+    "ap-south-1"     = ["18.96.228.0/26"]
+    "us-east-2"      = ["18.97.138.64/26"]
+    "us-west-2"      = ["18.98.18.192/26"]
+    "custom"         = ["0.0.0.0/0"]
+  }
+}

--- a/tests/coralogix-aws-shipper/coralogix-aws-shipper.tf
+++ b/tests/coralogix-aws-shipper/coralogix-aws-shipper.tf
@@ -34,6 +34,7 @@ module "s3-sqs-external-policy" {
   sqs_name                = "github-action-sqs-testing"
   integration_type        = "S3"
   create_sqs_queue_policy = false
+  s3_notification         = false
 }
 module "cloudwatch" {
   source = "../../modules/coralogix-aws-shipper"

--- a/tests/coralogix-aws-shipper/coralogix-aws-shipper.tf
+++ b/tests/coralogix-aws-shipper/coralogix-aws-shipper.tf
@@ -22,6 +22,19 @@ module "s3" {
   s3_bucket_name   = "github-action-bucket-testing"
   integration_type = "S3"
 }
+
+module "s3-sqs-external-policy" {
+  source = "../../modules/coralogix-aws-shipper"
+
+  coralogix_region        = "EU1"
+  api_key                 = "{{ secrets.TESTING_PRIVATE_KEY }}"
+  application_name        = "s3-sqs"
+  subsystem_name          = "logs"
+  s3_bucket_name          = "github-action-bucket-testing"
+  sqs_name                = "github-action-sqs-testing"
+  integration_type        = "S3"
+  create_sqs_queue_policy = false
+}
 module "cloudwatch" {
   source = "../../modules/coralogix-aws-shipper"
 


### PR DESCRIPTION
# Description

  - Added `create_sqs_queue_policy` variable (bool, default `true`) to allow users to opt out of SQS queue policy management
  - When set to `false`, the module skips creating `aws_sqs_queue_policy`, letting users manage the policy externally without drift
  - Follows the same pattern as `create_sns_topic_policy` (introduced in v3.10.4)

  ## Motivation
  Customers using S3/SQS integration reported that the module overrides their externally-managed SQS policy, breaking additional dependencies and causing persistent Terraform drift.

  ## Changes
  - `variables.tf` — new `create_sqs_queue_policy` variable
  - `Sqs.tf` — added flag to `aws_sqs_queue_policy` count condition
  - `README.md` — added variable to inputs table + custom SQS policy management section with required permissions
  - `CHANGELOG.md` — added v4.3.2 entry

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)