### PR TITLE
ci(docs-sync): include firehose-logs and firehose-metrics READMEs

### DIFF
--- a/.github/workflows/documentation-sync.yaml
+++ b/.github/workflows/documentation-sync.yaml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'examples/coralogix-aws-shipper/README.md'
       - 'modules/coralogix-aws-shipper/README.md'
+      - 'modules/firehose-logs/README.md'
+      - 'modules/firehose-metrics/README.md'
 
 jobs:
   trigger_action:


### PR DESCRIPTION
## Summary
- The docs portal syncs `modules/firehose-logs/README.md` and `modules/firehose-metrics/README.md` (rendered under `/docs/integrations/aws/amazon-data-firehose/...`), but the path filter in `documentation-sync.yaml` only listed the coralogix-aws-shipper README — so edits to either firehose module README didn't trigger a docs deploy.
- Extend the path filter so any of the four synced READMEs fires `trigger-deploy`.

Found while auditing all `coralogix/documentation` source repos for trigger coverage.

## Test plan
- [ ] After merge, push a trivial change to `modules/firehose-logs/README.md` on `master` and verify the workflow runs and the docs deploy is triggered.
- [ ] Same for `modules/firehose-metrics/README.md`.
- [ ] Confirm the existing `coralogix-aws-shipper` README path still triggers (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)