### PR TITLE
ci: notify coralogix/documentation on new release

### DIFF
--- a/.github/workflows/notify-docs-version-bump.yml
+++ b/.github/workflows/notify-docs-version-bump.yml
@@ -1,0 +1,53 @@
+name: Notify docs on version bump
+
+# Primary trigger for docs version tracking. This workflow fires immediately when a
+# release is published in coralogix/terraform-coralogix-aws and dispatches a
+# component-version-bump event to coralogix/documentation.
+#
+# Polling fallback is in coralogix/documentation/.github/workflows/poll-terraform.yml
+# (runs daily at 08:00 UTC and catches any dispatch this workflow may have missed).
+#
+# Required secret: GH_TOKEN — a PAT with repo scope on coralogix/documentation,
+# stored in coralogix/terraform-coralogix-aws repository secrets.
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    # Only run for published stable releases. Manual (workflow_dispatch) runs have
+    # no github.event.release payload, so guard on the event type to avoid
+    # dispatching empty new_version/old_version data to the docs repo.
+    if: ${{ github.event_name == 'release' && !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve previous stable release
+        id: prev
+        run: |
+          PREV=$(curl -s \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/releases" \
+            | jq -r --arg new "${{ github.event.release.tag_name }}" \
+              '[.[] | select(.prerelease == false and .draft == false) | .tag_name]
+               | map(select(. != $new)) | .[0] // ""')
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger docs version bump
+        run: |
+          curl --fail-with-body -X POST \
+               -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/coralogix/documentation/dispatches \
+               -d "{
+                 \"event_type\": \"component-version-bump\",
+                 \"client_payload\": {
+                   \"component\": \"terraform_coralogix_aws\",
+                   \"new_version\": \"${{ github.event.release.tag_name }}\",
+                   \"old_version\": \"${{ steps.prev.outputs.prev }}\"
+                 }
+               }"


### PR DESCRIPTION
## Summary

Adds a workflow that fires when a release is published in this repo and notifies the [coralogix/documentation](https://github.com/coralogix/documentation) repo to update versioned docs automatically.

- Triggers on `release: published` (skips pre-releases and drafts)
- Resolves the previous stable release tag so the docs classifier can compute a delta
- Dispatches a `component-version-bump` event with `component: terraform_coralogix_aws`, `new_version`, and `old_version`

## Requirements

Add a repository secret **`GH_TOKEN`** — a PAT with `repo` scope on `coralogix/documentation`.

## Fallback

A daily polling workflow (`poll-terraform.yml`) already exists in `coralogix/documentation` as a safety net. This push trigger gives immediate detection on release day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)