### PR TITLE
docs: add eventbridge and ecs-ec2 to documentation dispatch trigger

### DIFF
--- a/.github/workflows/documentation-sync.yaml
+++ b/.github/workflows/documentation-sync.yaml
@@ -10,6 +10,8 @@ on:
       - 'modules/coralogix-aws-shipper/README.md'
       - 'modules/firehose-logs/README.md'
       - 'modules/firehose-metrics/README.md'
+      - 'modules/eventbridge/README.md'
+      - 'modules/ecs-ec2/README.md'
 
 jobs:
   trigger_action:


### PR DESCRIPTION
## Summary

- Adds `modules/eventbridge/README.md` and `modules/ecs-ec2/README.md` to the `documentation-sync.yaml` dispatch trigger
- These modules are now synced into the Coralogix docs repo as hybrid-sync external pages
- When these READMEs change on master, the docs site will automatically redeploy

## Why

Both modules are referenced from Coralogix documentation pages as external synced content. Without these paths in the dispatch trigger, README updates in these modules would not propagate to the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)