### PR TITLE
fix: cds[2992] - upload lambda zip with correct S3 key in firehose-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.3.5
+
+#### **firehose-metrics**
+### 💡 bug fix 💡
+- Fix lambda processor `NoSuchKey` error when using `custom_s3_bucket` (e.g. GovCloud deployments). The local-exec was uploading the zip with key `bootstrap.zip` while the Lambda resource expected `firehose-metrics-transformer.zip`.
+
 ## v4.3.4
 
 #### **coralogix-aws-shipper**

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -60,12 +60,12 @@ resource "null_resource" "s3_bucket_copy" {
 
   provisioner "local-exec" {
     command = <<-EOF
-      curl -o bootstrap.zip https://coralogix-serverless-repo-eu-west-1.s3.eu-west-1.amazonaws.com/firehose-metrics-transformer.zip
-      aws s3 cp --region ${data.aws_region.current_region.id} ./bootstrap.zip s3://${var.custom_s3_bucket}
-      if [ -f bootstrap.zip ]; then
-        rm ./bootstrap.zip
+      curl -o firehose-metrics-transformer.zip https://coralogix-serverless-repo-eu-west-1.s3.eu-west-1.amazonaws.com/firehose-metrics-transformer.zip
+      aws s3 cp --region ${data.aws_region.current_region.id} ./firehose-metrics-transformer.zip s3://${var.custom_s3_bucket}/firehose-metrics-transformer.zip
+      if [ -f firehose-metrics-transformer.zip ]; then
+        rm ./firehose-metrics-transformer.zip
       else
-        echo "Couldn't find bootstrap.zip, skip deleting"
+        echo "Couldn't find firehose-metrics-transformer.zip, skip deleting"
       fi
 
     EOF


### PR DESCRIPTION
## Summary
- Fix `NoSuchKey` error on `aws_lambda_function.lambda_processor` apply when `custom_s3_bucket` is set (notably GovCloud deployments).
- Root cause: `null_resource.s3_bucket_copy` did `aws s3 cp ./bootstrap.zip s3://<custom_s3_bucket>`, which uploads the object with key `bootstrap.zip`. The Lambda resource looks for key `firehose-metrics-transformer.zip`. Mismatch was introduced in #281 when the artifact was renamed at the lambda resource and at the curl source but the s3 cp destination key was not updated.
- Fix: rename the local file to `firehose-metrics-transformer.zip` and pass it explicitly as the destination key in `aws s3 cp`, so the uploaded object matches the key the Lambda resource expects.

## Test plan
- [ ] `terraform init && terraform plan` in a fixture that sets `custom_s3_bucket`
- [ ] `terraform apply` in a GovCloud account with `custom_s3_bucket` set; confirm `s3://<bucket>/firehose-metrics-transformer.zip` exists after the null_resource runs and that `aws_lambda_function.lambda_processor` is created without `NoSuchKey`
- [ ] Confirm commercial-region path (no `custom_s3_bucket`) is unaffected — null_resource has `count = 0`, lambda still pulls from `coralogix-serverless-repo-<region>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)