### PR TITLE
feat(coralogix-aws-shipper): add FIPS env var controls for GovCloud deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v4.3.6
+## v4.4.0
 
 #### **coralogix-aws-shipper**
 ### 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.3.6
+
+#### **coralogix-aws-shipper**
+### 💡 Enhancements 💡
+- Added `enable_aws_fips` and `aws_use_fips_endpoint` variables to control the shipper Lambda's FIPS environment variables (`ENABLE_AWS_FIPS`, `AWS_USE_FIPS_ENDPOINT`). When `govcloud_deployment = true`, both default to `true` (FIPS 140-3 enabled) and can be explicitly set to `false` to disable. No effect when `govcloud_deployment = false`.
+
 ## v4.3.5
 
 #### **firehose-metrics**

--- a/examples/coralogix-aws-shipper/variables.tf
+++ b/examples/coralogix-aws-shipper/variables.tf
@@ -408,6 +408,18 @@ variable "govcloud_deployment" {
   default     = false
 }
 
+variable "enable_aws_fips" {
+  description = "Controls the ENABLE_AWS_FIPS environment variable on the shipper Lambda, which switches the AWS SDK HTTP client to the AWS-LC FIPS-validated TLS provider. When govcloud_deployment is true, this defaults to true (FIPS 140-3 enabled). Set to false to explicitly disable. Has no effect when govcloud_deployment is false."
+  type        = bool
+  default     = null
+}
+
+variable "aws_use_fips_endpoint" {
+  description = "Controls the AWS_USE_FIPS_ENDPOINT environment variable on the shipper Lambda, routing AWS SDK calls to FIPS service endpoints. When govcloud_deployment is true, this defaults to true. Set to false to explicitly disable. Has no effect when govcloud_deployment is false."
+  type        = bool
+  default     = null
+}
+
 variable "telemetry_mode" {
   description = "The telemetry mode for the shipper, i.e metrics or logs"
   type        = string

--- a/modules/coralogix-aws-shipper/README.md
+++ b/modules/coralogix-aws-shipper/README.md
@@ -182,12 +182,33 @@ If you're deploying multiple integrations through the same S3 bucket, you'll nee
 | <a name="input_notification_email"></a> [notification_email](#input\_notification\_email) | A failure notification to be sent to the email address. | `string` |  n/a | no |
 | <a name="input_custom_s3_bucket"></a> [custom\_s3\_bucket](#input\_custom\_s3\_bucket) | The name of an existing S3 bucket in your region, in which the Lambda zip code will be uploaded to. | `string` | n/a | no |
 | <a name="input_govcloud_deployment"></a> [govcloud\_deployment](#input\_govcloud\_deployment) | Enable if you deploy the integration in govcloud | `bool` | false | no |
+| <a name="input_enable_aws_fips"></a> [enable\_aws\_fips](#input\_enable\_aws\_fips) | Controls the `ENABLE_AWS_FIPS` environment variable on the shipper Lambda, switching the AWS SDK HTTP client to the AWS-LC FIPS-validated TLS provider. When `govcloud_deployment = true`, this defaults to `true` (FIPS 140-3 enabled). Set to `false` to explicitly disable. Has no effect when `govcloud_deployment = false`. | `bool` | `null` | no |
+| <a name="input_aws_use_fips_endpoint"></a> [aws\_use\_fips\_endpoint](#input\_aws\_use\_fips\_endpoint) | Controls the `AWS_USE_FIPS_ENDPOINT` environment variable on the shipper Lambda, routing AWS SDK calls to FIPS service endpoints. When `govcloud_deployment = true`, this defaults to `true`. Set to `false` to explicitly disable. Has no effect when `govcloud_deployment = false`. | `bool` | `null` | no |
 
 **Custom S3 bucket**
 
 Use the `custom_s3_bucket` variable only when deploying the integration in an AWS region where CX does not provide a public bucket (e.g., GovCloud). When using this variable, you must create an S3 bucket in the desired region for the integration. After that, pass the bucket name as `custom_s3_bucket`. The module will download the integration file to your local workspace, upload it to the custom_s3_bucket, and then remove the file from your local workspace once the process is complete.
 
-When using this variable you will need to create an S3 bucket in the region where you want to run the integration. Then, pass this bucket name as `custom_s3_bucket`. The module will download the integration file to your local workspace, and then upload these files to the `custom_s3_bucket`. At the end, remove the file from your local workspace once the process is complete. 
+When using this variable you will need to create an S3 bucket in the region where you want to run the integration. Then, pass this bucket name as `custom_s3_bucket`. The module will download the integration file to your local workspace, and then upload these files to the `custom_s3_bucket`. At the end, remove the file from your local workspace once the process is complete.
+
+**AWS GovCloud and FIPS**
+
+A single shipper artifact supports both commercial and GovCloud deployments; FIPS is toggled at runtime via Lambda environment variables. When `govcloud_deployment = true`, the module sets both `ENABLE_AWS_FIPS=true` and `AWS_USE_FIPS_ENDPOINT=true` on the Lambda by default, which routes all AWS SDK calls to FIPS service endpoints and uses the AWS-LC FIPS-validated TLS provider.
+
+If you need to disable FIPS in a GovCloud deployment, set the corresponding variable explicitly:
+
+```hcl
+module "coralogix-shipper" {
+  source = "coralogix/aws/coralogix//modules/coralogix-aws-shipper"
+
+  govcloud_deployment   = true
+  enable_aws_fips       = false  # disable AWS-LC FIPS TLS provider
+  aws_use_fips_endpoint = false  # disable FIPS service endpoints
+  # ...
+}
+```
+
+When `govcloud_deployment = false`, these variables are ignored and the env vars are not set on the Lambda.
 
 ### Lambda configuration (optional)
 

--- a/modules/coralogix-aws-shipper/main.tf
+++ b/modules/coralogix-aws-shipper/main.tf
@@ -314,6 +314,8 @@ module "lambda" {
     FILE_CACHE_EXPIRATION          = var.telemetry_mode == "metrics" ? var.metrics_file_cache_expiration : null
     STARLARK_SCRIPT                = var.starlark_script != "" ? var.starlark_script : null
     LOG_STREAM_FILTER              = var.log_stream_filter != "" ? var.log_stream_filter : null
+    ENABLE_AWS_FIPS                = var.govcloud_deployment ? (var.enable_aws_fips == null ? "true" : tostring(var.enable_aws_fips)) : null
+    AWS_USE_FIPS_ENDPOINT          = var.govcloud_deployment ? (var.aws_use_fips_endpoint == null ? "true" : tostring(var.aws_use_fips_endpoint)) : null
   }
   s3_existing_package = {
     bucket = var.custom_s3_bucket == "" ? "coralogix-serverless-repo-${data.aws_region.this.id}" : var.custom_s3_bucket

--- a/modules/coralogix-aws-shipper/variables.tf
+++ b/modules/coralogix-aws-shipper/variables.tf
@@ -364,6 +364,18 @@ variable "govcloud_deployment" {
   default     = false
 }
 
+variable "enable_aws_fips" {
+  description = "Controls the ENABLE_AWS_FIPS environment variable on the shipper Lambda, which switches the AWS SDK HTTP client to the AWS-LC FIPS-validated TLS provider. When govcloud_deployment is true, this defaults to true (FIPS 140-3 enabled). Set to false to explicitly disable. Has no effect when govcloud_deployment is false."
+  type        = bool
+  default     = null
+}
+
+variable "aws_use_fips_endpoint" {
+  description = "Controls the AWS_USE_FIPS_ENDPOINT environment variable on the shipper Lambda, routing AWS SDK calls to FIPS service endpoints. When govcloud_deployment is true, this defaults to true. Set to false to explicitly disable. Has no effect when govcloud_deployment is false."
+  type        = bool
+  default     = null
+}
+
 variable "lambda_name" {
   type        = string
   description = "The name of the lambda function"


### PR DESCRIPTION
# Description

Adds two new variables to the `coralogix-aws-shipper` module to expose the FIPS-related environment variables introduced in coralogix-aws-shipper v1.4.8 (single unified artifact with runtime FIPS support):

- `enable_aws_fips` — controls `ENABLE_AWS_FIPS` on the Lambda (AWS-LC FIPS TLS provider)
- `aws_use_fips_endpoint` — controls `AWS_USE_FIPS_ENDPOINT` on the Lambda (FIPS service endpoints)

Behavior:
- When `govcloud_deployment = true`, both env vars default to `"true"` (FIPS 140-3 enabled by default in GovCloud).
- Users can override explicitly by setting either variable to `false`.
- When `govcloud_deployment = false`, the env vars are not set (commercial deployments unaffected).

This mirrors the `template-govcloud.yaml` defaults in the shipper repo and consolidates the toggle through the Terraform module.

# How Has This Been Tested?

- `terraform fmt -recursive modules/coralogix-aws-shipper examples/coralogix-aws-shipper` — clean.
- `terraform -chdir=modules/coralogix-aws-shipper init -backend=false && terraform validate` — `Success! The configuration is valid` (only pre-existing `aws_cloudwatch_log_group.id` deprecation warnings, unrelated).

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [ ] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)

