### PR TITLE
feat:  add support for the Supervisor in the ecs-ec2 module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,3 +110,9 @@ jobs:
           chmod +x verify-service-only-mode.sh
           ./verify-service-only-mode.sh
 
+      - if: ${{ github.event.pull_request.head.repo.full_name == github.repository && matrix.package == 'ecs-ec2' }}
+        name: Verify supervised mode configs and permissions
+        run: |
+          cd "tests/ecs-ec2"
+          chmod +x verify-supervised-mode.sh
+          ./verify-supervised-mode.sh

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ terraform.rc
 .vscode/
 .DS_Store
 **/.DS_Store
+/.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 #### **ecs-ec2**
 ### 💡 Enhancements 💡
 - Added Supervisor mode to `ecs-ec2`, controlled by `supervisor_enabled`, with supervised CDOT `v0.10.0`, embedded NOP bootstrap configs, and optional S3 overrides.
-- S3 task roles are now created only when an S3 config is selected. Runtime S3 access includes object reads and bucket listing; the execution role no longer receives runtime S3 permissions.
+- When the module creates the task definition without a custom task role, it creates a task role with runtime S3 object-read and bucket-listing permissions. This keeps planning working when S3 bucket or key values are computed; the execution role no longer receives runtime S3 permissions.
 
 ## v4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### **ecs-ec2**
+### 💡 Enhancements 💡
+- Added Supervisor mode to `ecs-ec2` with supervised CDOT `v0.10.0`, embedded NOP bootstrap configs, and optional S3 overrides.
+- S3 task roles are now created only when an S3 config is selected. Runtime S3 access includes object reads and bucket listing; the execution role no longer receives runtime S3 permissions.
+
 ## v4.4.0
 
 #### **coralogix-aws-shipper**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v4.5.0
 
 #### **ecs-ec2**
 ### 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### **ecs-ec2**
 ### 💡 Enhancements 💡
-- Added Supervisor mode to `ecs-ec2` with supervised CDOT `v0.10.0`, embedded NOP bootstrap configs, and optional S3 overrides.
+- Added Supervisor mode to `ecs-ec2`, controlled by `supervisor_enabled`, with supervised CDOT `v0.10.0`, embedded NOP bootstrap configs, and optional S3 overrides.
 - S3 task roles are now created only when an S3 config is selected. Runtime S3 access includes object reads and bucket listing; the execution role no longer receives runtime S3 permissions.
 
 ## v4.4.0

--- a/examples/ecs-ec2/README.md
+++ b/examples/ecs-ec2/README.md
@@ -6,7 +6,7 @@ This example demonstrates how to deploy the Coralogix OpenTelemetry Agent as a D
 
 Save this code in a Terraform file and change the values according to your settings.
 
-**Note**: Before deploying, ensure you have uploaded the required OpenTelemetry configuration to your S3 bucket. The config should be generated from the **Coralogix UI AWS ECS-EC2 integration**. Alternatively, you can use the [example config from the integration chart](https://github.com/coralogix/telemetry-shippers/blob/master/otel-ecs-ec2/examples/otel-config.yaml) as a reference—note that values such as domain may differ from your setup.
+**Note**: When using collector mode, ensure you have uploaded the required OpenTelemetry configuration to your S3 bucket before deploying. The config should be generated from the **Coralogix UI AWS ECS-EC2 integration**. Alternatively, you can use the [example config from the integration chart](https://github.com/coralogix/telemetry-shippers/blob/master/otel-ecs-ec2/examples/otel-config.yaml) as a reference—note that values such as domain may differ from your setup.
 
 ## Configuration Examples
 
@@ -41,6 +41,21 @@ module "otel_ecs_ec2_coralogix" {
   health_check_timeout  = 5
   health_check_retries  = 3
   memory                = 2048
+}
+```
+
+### Supervisor with Embedded Configurations
+
+Supervisor mode uses the supervised image and embeds the default Supervisor and Collector configurations when no S3 paths are provided.
+
+```hcl
+module "otel_ecs_ec2_coralogix" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name    = "my-ecs-cluster"
+  supervisor_enabled = true
+  coralogix_region    = "EU1"
+  api_key             = "your-coralogix-api-key"
 }
 ```
 

--- a/examples/ecs-ec2/README.md
+++ b/examples/ecs-ec2/README.md
@@ -46,7 +46,7 @@ module "otel_ecs_ec2_coralogix" {
 
 ### Using Secrets Manager for API Key
 
-The module auto-creates an execution role with S3 and Secrets Manager access when `task_execution_role_arn` is not provided:
+The module auto-creates an execution role with the standard ECS execution policy and Secrets Manager access when `task_execution_role_arn` is not provided. Runtime S3 access is granted through the task role:
 
 ```hcl
 module "otel_ecs_ec2_coralogix" {
@@ -101,7 +101,7 @@ module "otel_ecs_ec2_coralogix" {
 }
 ```
 
-**Note**: When providing a custom `task_role_arn`, ensure it has at minimum S3 read permissions (`s3:GetObject`, `s3:GetObjectVersion`) for the configuration bucket, as containers need to access S3 at runtime to read their configuration files.
+**Note**: When providing a custom `task_role_arn`, ensure it has `s3:GetObject`, `s3:GetObjectVersion`, and `s3:ListBucket` permissions for the configuration bucket, as the config-loader container accesses S3 at runtime.
 
 ## IAM Role Management
 
@@ -109,13 +109,13 @@ The module separates execution roles and task roles for better security followin
 
 ### Execution Role
 Used by ECS for infrastructure operations (pulling images, retrieving secrets, etc.):
-- **Auto-created Role**: Created with S3 read permissions for configuration files (if no custom role provided)
+- **Auto-created Role**: Created with the standard ECS task execution policy
 - **Custom Role**: Users can provide their own execution role via `task_execution_role_arn`
-- **Secrets Manager**: `task_execution_role_arn` must be provided when `use_api_key_secret` is true
+- **Secrets Manager**: The module adds secret access to the auto-created role when `use_api_key_secret` is true
 
 ### Task Role
 Used by the running container at runtime for AWS API access:
-- **Auto-created Role**: A minimal task role with S3 read-only permissions is automatically created if no custom `task_role_arn` is provided
+- **Auto-created Role**: A minimal task role with S3 read permissions is created when an S3 config is selected and no custom `task_role_arn` is provided
 - **Custom Role**: Users can provide their own task role via `task_role_arn` for additional AWS service access if needed
 
 ## Quick Start

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -10,7 +10,9 @@ The OTEL agent is deployed as a Daemon ECS Task and connected using [```host``` 
 
 The OTEL agent uses a [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filereceiver) to read the docker logs of all containers on the EC2 host. OTLP is also accepted. Coralogix provides the ```awsecscontainermetricsd``` receiver which enables metrics collection of all tasks on the same host. The [coralogix exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter) forwards telemetry to your configured Coralogix endpoint.
 
-The module loads the OpenTelemetry configuration from S3. The config should be generated from the **Coralogix UI AWS ECS-EC2 integration**. Alternatively, you can use the [example config from the integration chart](https://github.com/coralogix/telemetry-shippers/blob/master/otel-ecs-ec2/examples/otel-config.yaml) as a reference—note that values such as domain may differ from your setup.
+In `collector` mode, the module loads the OpenTelemetry configuration from S3. The config should be generated from the **Coralogix UI AWS ECS-EC2 integration**. Alternatively, you can use the [example config from the integration chart](https://github.com/coralogix/telemetry-shippers/blob/master/otel-ecs-ec2/examples/otel-config.yaml) as a reference—note that values such as domain may differ from your setup.
+
+In `supervised` mode, the module uses the supervised image, embeds a NOP Collector bootstrap config and the default Supervisor config. Set `s3_config_bucket` with `s3_config_key` or `s3_supervisor_config_key` to override either embedded config from S3. An S3 path always takes priority over the matching embedded config.
 
 The module passes these environment variables to the collector:
 - `CORALOGIX_DOMAIN` – region-specific domain (from coralogix_region)
@@ -32,6 +34,19 @@ module "ecs-ec2" {
   task_definition_arn  = "arn:aws:ecs:region:account:task-definition/name:revision"
   task_execution_role_arn = null  # required
   task_role_arn        = null     # required
+}
+```
+
+For supervised mode with embedded configs:
+
+```terraform
+module "ecs-ec2" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name     = "my-cluster"
+  image_mode          = "supervised"
+  coralogix_region     = "EU1"
+  api_key              = "your-coralogix-api-key"
 }
 ```
 
@@ -89,20 +104,24 @@ You can control health checks using:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ecs_cluster_name | Name of the AWS ECS Cluster | `string` | n/a | yes |
-| image_version | Coralogix OTEL Collector image version/tag | `string` | `null` | yes* |
+| image_mode | Image mode: `collector` or `supervised` | `string` | `"collector"` | no |
+| image_version | Standard Coralogix Otel Collector image version/tag used in collector mode | `string` | `null` | yes* |
+| supervised_image_repository | Supervised Coralogix Otel Collector image repository | `string` | `"cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot"` | no |
+| supervised_image_version | Supervised Coralogix Otel Collector image version/tag | `string` | `"v0.10.0"` | no |
 | coralogix_region | Coralogix region: EU1, EU2, AP1, AP2, AP3, US1, US2, custom | `string` | `null` | yes* |
 | api_key | Send-Your-Data API key | `string` | `null` | yes** |
-| s3_config_bucket | S3 bucket containing the OTEL config | `string` | `null` | yes* |
-| s3_config_key | S3 object key for the config file | `string` | `null` | yes* |
-| config_source | Reserved for UI compatibility. Only 's3' supported. | `string` | `"s3"` | no |
+| s3_config_bucket | S3 bucket containing collector and optional Supervisor configs | `string` | `null` | yes* |
+| s3_config_key | S3 object key for the collector config | `string` | `null` | yes* |
+| s3_supervisor_config_key | Optional S3 object key for the Supervisor config | `string` | `null` | no |
+| config_source | Reserved for UI compatibility. Keep set to `s3`. | `string` | `"s3"` | no |
 | image | OTEL Collector image | `string` | `"coralogixrepo/coralogix-otel-collector"` | no |
 | memory | Task memory (MiB) | `number` | `256` | no |
 | custom_domain | Custom Coralogix domain (e.g. Private Link) | `string` | `null` | no |
 | use_api_key_secret | Use API key from Secrets Manager | `bool` | `false` | no |
 | api_key_secret_arn | ARN of Secrets Manager secret | `string` | `null` | no |
 | api_key_secret_kms_key_arn | KMS key ARN for the secret. When set, skips DescribeSecret/DescribeKey (use when deploy role cannot access secret metadata). | `string` | `null` | no |
-| task_execution_role_arn | Custom execution role. When null, module auto-creates one (S3 + optional Secrets Manager). Must be null in service-only mode. | `string` | `null` | no |
-| task_role_arn | Custom task role. When null, module auto-creates one with S3 read. Must be null in service-only mode. | `string` | `null` | no |
+| task_execution_role_arn | Custom execution role. When null, module auto-creates one with the standard ECS execution policy and optional Secrets Manager access. Must be null in service-only mode. | `string` | `null` | no |
+| task_role_arn | Custom task role. When an S3 config is selected and this is null, the module creates one with S3 read access. Must be null in service-only mode. | `string` | `null` | no |
 | health_check_enabled | Enable ECS container health check | `bool` | `false` | no |
 | health_check_interval | Health check interval (seconds) | `number` | `30` | no |
 | health_check_timeout | Health check timeout (seconds) | `number` | `5` | no |
@@ -111,7 +130,7 @@ You can control health checks using:
 | tags | Resource tags | `map(string)` | `null` | no |
 | task_definition_arn | Existing task definition ARN. When set, service-only mode: module creates only the ECS service; S3/roles ignored; task_execution_role_arn and task_role_arn must be null. | `string` | `null` | no |
 
-\* Required when `task_definition_arn` is null (module creates the task definition). Ignored in service-only mode.
+\* Required in collector mode when `task_definition_arn` is null. Supervised mode uses embedded configs and its own default image when these values are omitted.
 
 \** Required unless `use_api_key_secret` is true (when module creates the task definition).
 

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -121,7 +121,7 @@ You can control health checks using:
 | api_key_secret_arn | ARN of Secrets Manager secret | `string` | `null` | no |
 | api_key_secret_kms_key_arn | KMS key ARN for the secret. When set, skips DescribeSecret/DescribeKey (use when deploy role cannot access secret metadata). | `string` | `null` | no |
 | task_execution_role_arn | Custom execution role. When null, module auto-creates one with the standard ECS execution policy and optional Secrets Manager access. Must be null in service-only mode. | `string` | `null` | no |
-| task_role_arn | Custom task role. When an S3 config is selected and this is null, the module creates one with S3 read access. Must be null in service-only mode. | `string` | `null` | no |
+| task_role_arn | Custom task role. When null, module auto-creates one with S3 read access. Must be null in service-only mode. | `string` | `null` | no |
 | health_check_enabled | Enable ECS container health check | `bool` | `false` | no |
 | health_check_interval | Health check interval (seconds) | `number` | `30` | no |
 | health_check_timeout | Health check timeout (seconds) | `number` | `5` | no |

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -37,14 +37,14 @@ module "ecs-ec2" {
 }
 ```
 
-For supervised mode with embedded configs:
+For Supervisor mode with embedded configs:
 
 ```terraform
 module "ecs-ec2" {
   source = "coralogix/aws/coralogix//modules/ecs-ec2"
 
   ecs_cluster_name     = "my-cluster"
-  image_mode          = "supervised"
+  supervisor_enabled = true
   coralogix_region     = "EU1"
   api_key              = "your-coralogix-api-key"
 }
@@ -104,7 +104,7 @@ You can control health checks using:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ecs_cluster_name | Name of the AWS ECS Cluster | `string` | n/a | yes |
-| image_mode | Image mode: `collector` or `supervised` | `string` | `"collector"` | no |
+| supervisor_enabled | Run the Collector through the Supervisor | `bool` | `false` | no |
 | image_version | Standard Coralogix Otel Collector image version/tag used in collector mode | `string` | `null` | yes* |
 | supervised_image_repository | Supervised Coralogix Otel Collector image repository | `string` | `"cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot"` | no |
 | supervised_image_version | Supervised Coralogix Otel Collector image version/tag | `string` | `"v0.10.0"` | no |

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -17,9 +17,6 @@ locals {
   s3_config_bucket         = var.s3_config_bucket == null ? "" : var.s3_config_bucket
   s3_config_key            = var.s3_config_key == null ? "" : var.s3_config_key
   s3_supervisor_config_key = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
-  use_s3_collector_config  = local.s3_config_bucket != "" && local.s3_config_key != ""
-  use_s3_supervisor_config = local.use_supervised_image && local.s3_config_bucket != "" && local.s3_supervisor_config_key != ""
-  use_any_s3_config        = local.use_s3_collector_config || local.use_s3_supervisor_config
   execution_role_arn       = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
   task_role_arn            = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 
@@ -192,7 +189,7 @@ resource "aws_iam_role_policy" "otel_task_execution_role_secrets" {
 
 # IAM Role for task runtime S3 access (created when module creates task definition and no custom task role provided)
 resource "aws_iam_role" "otel_task_role_s3" {
-  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
   name  = "${local.name}-${random_string.id.result}-task-role-s3"
 
   assume_role_policy = jsonencode({
@@ -212,7 +209,7 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
   name  = "S3ReadAccess"
   role  = aws_iam_role.otel_task_role_s3[0].id
 

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -208,7 +208,8 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null && !(var.supervisor_enabled &&
+var.s3_config_bucket == null) ? 1 : 0
   name  = "S3ReadAccess"
   role  = aws_iam_role.otel_task_role_s3[0].id
 

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -13,7 +13,7 @@ locals {
   coralogix_region_domain_map = module.locals_variables.coralogix_domains
   coralogix_domain            = var.task_definition_arn == null ? coalesce(var.custom_domain, local.coralogix_region_domain_map[var.coralogix_region]) : null
 
-  use_supervised_image     = var.image_mode == "supervised"
+  use_supervised_image     = var.supervisor_enabled
   s3_config_bucket         = var.s3_config_bucket == null ? "" : var.s3_config_bucket
   s3_config_key            = var.s3_config_key == null ? "" : var.s3_config_key
   s3_supervisor_config_key = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
@@ -87,14 +87,14 @@ locals {
     set -e
     if [ -n "$S3_CONFIG_BUCKET" ] && [ -n "$S3_CONFIG_KEY" ]; then
       aws s3 cp "s3://$S3_CONFIG_BUCKET/$S3_CONFIG_KEY" /otel-config/collector-config.yaml
-    elif [ "$IMAGE_MODE" = "supervised" ]; then
+    elif [ "$SUPERVISOR_ENABLED" = "true" ]; then
       printf '%s\n' "$COLLECTOR_CONFIG" > /otel-config/collector-config.yaml
     else
       echo "s3_config_bucket and s3_config_key are required in collector mode" >&2
       exit 1
     fi
 
-    if [ "$IMAGE_MODE" = "supervised" ]; then
+    if [ "$SUPERVISOR_ENABLED" = "true" ]; then
       if [ -n "$S3_CONFIG_BUCKET" ] && [ -n "$S3_SUPERVISOR_CONFIG_KEY" ]; then
         aws s3 cp "s3://$S3_CONFIG_BUCKET/$S3_SUPERVISOR_CONFIG_KEY" /otel-config/supervisor.yaml
       else
@@ -277,8 +277,8 @@ resource "aws_ecs_task_definition" "coralogix_otel_agent" {
       environment = concat(
         [
           {
-            name  = "IMAGE_MODE"
-            value = var.image_mode
+            name  = "SUPERVISOR_ENABLED"
+            value = tostring(var.supervisor_enabled)
           },
           {
             name  = "S3_CONFIG_BUCKET"

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -99,8 +99,6 @@ locals {
       fi
     fi
   SH
-
-  collector_command = local.use_supervised_image ? "exec /opampsupervisor -config /otel-config/supervisor.yaml" : "exec /cdot --config /otel-config/collector-config.yaml"
 }
 
 module "locals_variables" {
@@ -109,6 +107,7 @@ module "locals_variables" {
   random_string    = random_string.id.result
 }
 
+data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 # Lookup secret metadata for KMS key ID. Skipped when api_key_secret_kms_key_arn is set (avoids DescribeSecret on deploy role).
@@ -313,8 +312,7 @@ resource "aws_ecs_task_definition" "coralogix_otel_agent" {
       image      = local.use_supervised_image ? "${var.supervised_image_repository}:${var.supervised_image_version}" : "${var.image}:${coalesce(var.image_version, "v0.5.10")}"
       essential  = true
       privileged = true
-      entryPoint = ["sh", "-c"]
-      command    = [local.collector_command]
+      command    = local.use_supervised_image ? ["--config", "/otel-config/supervisor.yaml"] : ["--config", "s3://${local.s3_config_bucket}.s3.${data.aws_region.current.region}.amazonaws.com/${local.s3_config_key}"]
       dependsOn = [
         {
           containerName = "config-loader"

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -13,8 +13,97 @@ locals {
   coralogix_region_domain_map = module.locals_variables.coralogix_domains
   coralogix_domain            = var.task_definition_arn == null ? coalesce(var.custom_domain, local.coralogix_region_domain_map[var.coralogix_region]) : null
 
-  execution_role_arn = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
-  task_role_arn      = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
+  use_supervised_image     = var.image_mode == "supervised"
+  s3_config_bucket         = var.s3_config_bucket == null ? "" : var.s3_config_bucket
+  s3_config_key            = var.s3_config_key == null ? "" : var.s3_config_key
+  s3_supervisor_config_key = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
+  use_s3_collector_config  = local.s3_config_bucket != "" && local.s3_config_key != ""
+  use_s3_supervisor_config = local.use_supervised_image && local.s3_config_bucket != "" && local.s3_supervisor_config_key != ""
+  use_any_s3_config        = local.use_s3_collector_config || local.use_s3_supervisor_config
+  execution_role_arn       = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
+  task_role_arn            = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
+
+  collector_config = <<-YAML
+    receivers:
+      nop:
+
+    exporters:
+      nop:
+
+    extensions:
+      health_check:
+        endpoint: "localhost:13133"
+
+    service:
+      extensions:
+        - health_check
+      telemetry:
+        logs:
+          encoding: json
+      pipelines:
+        traces:
+          receivers: [nop]
+          exporters: [nop]
+        metrics:
+          receivers: [nop]
+          exporters: [nop]
+        logs:
+          receivers: [nop]
+          exporters: [nop]
+  YAML
+
+  supervisor_config = <<-YAML
+    server:
+      endpoint: "https://ingress.$${env:CORALOGIX_DOMAIN}/opamp/v1"
+      headers:
+        Authorization: "Bearer $${env:CORALOGIX_PRIVATE_KEY}"
+      tls:
+        insecure_skip_verify: false
+
+    capabilities:
+      reports_effective_config: true
+      reports_own_metrics: true
+      reports_own_logs: true
+      reports_own_traces: true
+      reports_health: true
+      accepts_remote_config: true
+      reports_remote_config: true
+
+    agent:
+      executable: /cdot
+      passthrough_logs: true
+      config_files:
+        - /otel-config/collector-config.yaml
+
+    storage:
+      directory: /etc/otelcol-contrib/supervisor-data/
+
+    telemetry:
+      logs:
+        level: info
+  YAML
+
+  config_loader_command = <<-SH
+    set -e
+    if [ -n "$S3_CONFIG_BUCKET" ] && [ -n "$S3_CONFIG_KEY" ]; then
+      aws s3 cp "s3://$S3_CONFIG_BUCKET/$S3_CONFIG_KEY" /otel-config/collector-config.yaml
+    elif [ "$IMAGE_MODE" = "supervised" ]; then
+      printf '%s\n' "$COLLECTOR_CONFIG" > /otel-config/collector-config.yaml
+    else
+      echo "s3_config_bucket and s3_config_key are required in collector mode" >&2
+      exit 1
+    fi
+
+    if [ "$IMAGE_MODE" = "supervised" ]; then
+      if [ -n "$S3_CONFIG_BUCKET" ] && [ -n "$S3_SUPERVISOR_CONFIG_KEY" ]; then
+        aws s3 cp "s3://$S3_CONFIG_BUCKET/$S3_SUPERVISOR_CONFIG_KEY" /otel-config/supervisor.yaml
+      else
+        printf '%s\n' "$SUPERVISOR_CONFIG" > /otel-config/supervisor.yaml
+      fi
+    fi
+  SH
+
+  collector_command = local.use_supervised_image ? "exec /opampsupervisor -config /otel-config/supervisor.yaml" : "exec /cdot --config /otel-config/collector-config.yaml"
 }
 
 module "locals_variables" {
@@ -23,13 +112,12 @@ module "locals_variables" {
   random_string    = random_string.id.result
 }
 
-data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 # Lookup secret metadata for KMS key ID. Skipped when api_key_secret_kms_key_arn is set (avoids DescribeSecret on deploy role).
 data "aws_secretsmanager_secret" "api_key" {
-  count  = var.task_definition_arn == null && var.task_execution_role_arn == null && var.use_api_key_secret && var.api_key_secret_arn != null && (var.api_key_secret_kms_key_arn == null || var.api_key_secret_kms_key_arn == "") ? 1 : 0
-  arn    = var.api_key_secret_arn
+  count = var.task_definition_arn == null && var.task_execution_role_arn == null && var.use_api_key_secret && var.api_key_secret_arn != null && (var.api_key_secret_kms_key_arn == null || var.api_key_secret_kms_key_arn == "") ? 1 : 0
+  arn   = var.api_key_secret_arn
 }
 
 # Resolve KMS key ID or alias to key ARN (IAM kms:Decrypt requires key ARN, not alias). Skipped when api_key_secret_kms_key_arn is set (avoids DescribeKey on deploy role).
@@ -46,7 +134,7 @@ resource "random_string" "id" {
   special = false
 }
 
-# IAM Role for S3 access (created when module creates task definition and no custom execution role provided)
+# ECS task execution role (created when the module manages the task definition and no custom role is provided)
 resource "aws_iam_role" "otel_task_execution_role_s3" {
   count = var.task_definition_arn == null && var.task_execution_role_arn == null ? 1 : 0
   name  = "${local.name}-${random_string.id.result}-task-execution-role-s3"
@@ -71,26 +159,6 @@ resource "aws_iam_role_policy_attachment" "otel_task_execution_role_s3_policy" {
   count      = var.task_definition_arn == null && var.task_execution_role_arn == null ? 1 : 0
   role       = aws_iam_role.otel_task_execution_role_s3[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-}
-
-resource "aws_iam_role_policy" "otel_task_execution_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_execution_role_arn == null ? 1 : 0
-  name  = "S3ReadAccess"
-  role  = aws_iam_role.otel_task_execution_role_s3[0].id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:GetObjectVersion"
-        ]
-        Resource = "arn:aws:s3:::${var.s3_config_bucket}/*"
-      }
-    ]
-  })
 }
 
 # Secrets Manager access for API key (when use_api_key_secret, api_key_secret_arn set, and module creates execution role)
@@ -124,7 +192,7 @@ resource "aws_iam_role_policy" "otel_task_execution_role_secrets" {
 
 # IAM Role for task runtime S3 access (created when module creates task definition and no custom task role provided)
 resource "aws_iam_role" "otel_task_role_s3" {
-  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
   name  = "${local.name}-${random_string.id.result}-task-role-s3"
 
   assume_role_policy = jsonencode({
@@ -144,7 +212,7 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
   name  = "S3ReadAccess"
   role  = aws_iam_role.otel_task_role_s3[0].id
 
@@ -157,7 +225,14 @@ resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
           "s3:GetObject",
           "s3:GetObjectVersion"
         ]
-        Resource = "arn:aws:s3:::${var.s3_config_bucket}/*"
+        Resource = "arn:aws:s3:::${local.s3_config_bucket}/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = "arn:aws:s3:::${local.s3_config_bucket}"
       }
     ]
   })
@@ -169,8 +244,13 @@ resource "aws_ecs_task_definition" "coralogix_otel_agent" {
   cpu                      = max(var.memory, 256)
   memory                   = var.memory
   requires_compatibilities = ["EC2"]
+  network_mode             = "host"
   execution_role_arn       = local.execution_role_arn
   task_role_arn            = local.task_role_arn
+
+  volume {
+    name = "otel-config"
+  }
   volume {
     name      = "hostfs"
     host_path = "/var/lib/docker/"
@@ -179,78 +259,142 @@ resource "aws_ecs_task_definition" "coralogix_otel_agent" {
     name      = "docker-socket"
     host_path = "/var/run/docker.sock"
   }
+
   tags = merge(
     {
       Name = "${local.name}-${random_string.id.result}"
     },
     var.tags
   )
-  container_definitions = jsonencode([{
-    name : local.name
-    networkMode : "host"
-    image : "${var.image}:${coalesce(var.image_version, "v0.5.10")}"
-    essential : true
-    portMappings : [
-      {
-        containerPort : 4317
-        hostPort : 4317
-        appProtocol : "grpc"
-      },
-      {
-        containerPort : 4318
-        hostPort : 4318
-      },
-      {
-        containerPort : 8888
-        hostPort : 8888
-      },
-      {
-        containerPort : 13133
-        hostPort : 13133
+  container_definitions = jsonencode([
+    {
+      name              = "config-loader"
+      image             = "public.ecr.aws/aws-cli/aws-cli:2.28.17"
+      essential         = false
+      memoryReservation = 32
+      entryPoint        = ["sh", "-c"]
+      command           = [local.config_loader_command]
+      environment = concat(
+        [
+          {
+            name  = "IMAGE_MODE"
+            value = var.image_mode
+          },
+          {
+            name  = "S3_CONFIG_BUCKET"
+            value = local.s3_config_bucket
+          },
+          {
+            name  = "S3_CONFIG_KEY"
+            value = local.s3_config_key
+          },
+          {
+            name  = "S3_SUPERVISOR_CONFIG_KEY"
+            value = local.s3_supervisor_config_key
+          }
+        ],
+        local.use_supervised_image ? [
+          {
+            name  = "COLLECTOR_CONFIG"
+            value = local.collector_config
+          },
+          {
+            name  = "SUPERVISOR_CONFIG"
+            value = local.supervisor_config
+          }
+        ] : []
+      )
+      mountPoints = [
+        {
+          sourceVolume  = "otel-config"
+          containerPath = "/otel-config"
+        }
+      ]
+    },
+    {
+      name       = local.name
+      image      = local.use_supervised_image ? "${var.supervised_image_repository}:${var.supervised_image_version}" : "${var.image}:${coalesce(var.image_version, "v0.5.10")}"
+      essential  = true
+      privileged = true
+      entryPoint = ["sh", "-c"]
+      command    = [local.collector_command]
+      dependsOn = [
+        {
+          containerName = "config-loader"
+          condition     = "SUCCESS"
+        }
+      ]
+      portMappings = [
+        {
+          containerPort = 4317
+          hostPort      = 4317
+          appProtocol   = "grpc"
+        },
+        {
+          containerPort = 4318
+          hostPort      = 4318
+        },
+        {
+          containerPort = 8888
+          hostPort      = 8888
+        },
+        {
+          containerPort = 13133
+          hostPort      = 13133
+        }
+      ]
+      mountPoints = [
+        {
+          sourceVolume  = "otel-config"
+          containerPath = "/otel-config"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "hostfs"
+          containerPath = "/hostfs/var/lib/docker/"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "docker-socket"
+          containerPath = "/var/run/docker.sock"
+        }
+      ]
+      environment = concat(
+        [
+          {
+            name  = "CORALOGIX_DOMAIN"
+            value = local.coralogix_domain
+          },
+          {
+            name  = "MY_POD_IP"
+            value = "0.0.0.0"
+          }
+        ],
+        var.use_api_key_secret != true ? [
+          {
+            name  = "CORALOGIX_PRIVATE_KEY"
+            value = var.api_key
+          }
+        ] : []
+      )
+      secrets = var.use_api_key_secret == true ? [
+        {
+          name      = "CORALOGIX_PRIVATE_KEY"
+          valueFrom = var.api_key_secret_arn
+        }
+      ] : []
+      healthCheck = var.health_check_enabled ? {
+        command     = ["CMD", "/healthcheck"]
+        startPeriod = var.health_check_start_period
+        interval    = var.health_check_interval
+        timeout     = var.health_check_timeout
+        retries     = var.health_check_retries
+      } : null
+      logConfiguration = {
+        logDriver = "json-file"
       }
-    ],
-    privileged : true,
-    mountPoints : [
-      {
-        sourceVolume : "hostfs"
-        containerPath : "/hostfs/var/lib/docker/"
-        readOnly : true
-      },
-      {
-        sourceVolume : "docker-socket"
-        containerPath : "/var/run/docker.sock"
-      }
-    ],
-    environment : concat([
-      {
-        name : "CORALOGIX_DOMAIN"
-        value : local.coralogix_domain
-      },
-      {
-        name : "MY_POD_IP"
-        value : "0.0.0.0"
-      }
-      ],
-      var.use_api_key_secret != true ? [{
-        name : "CORALOGIX_PRIVATE_KEY"
-        value : var.api_key
-    }] : []),
-    secrets : var.use_api_key_secret == true ? [{
-      name      : "CORALOGIX_PRIVATE_KEY"
-      valueFrom : var.api_key_secret_arn
-    }] : [],
-    command : ["--config", "s3://${var.s3_config_bucket}.s3.${data.aws_region.current.id}.amazonaws.com/${var.s3_config_key}"],
-    healthCheck : var.health_check_enabled ? {
-      command     : ["/healthcheck"]
-      startPeriod : var.health_check_start_period
-      interval    : var.health_check_interval
-      timeout     : var.health_check_timeout
-      retries     : var.health_check_retries
-    } : null,
-    logConfiguration : {
-      logDriver : "json-file"
     }
-  }])
+  ])
 }
 
 resource "aws_ecs_service" "coralogix_otel_agent" {
@@ -260,7 +404,7 @@ resource "aws_ecs_service" "coralogix_otel_agent" {
   task_definition                    = var.task_definition_arn == null ? aws_ecs_task_definition.coralogix_otel_agent[0].arn : var.task_definition_arn
   scheduling_strategy                = "DAEMON"
   deployment_maximum_percent         = 100
-  deployment_minimum_healthy_percent  = 0
+  deployment_minimum_healthy_percent = 0
   deployment_circuit_breaker {
     enable   = true
     rollback = true

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -208,10 +208,11 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null && !(var.supervisor_enabled &&
-var.s3_config_bucket == null) ? 1 : 0
-  name  = "S3ReadAccess"
-  role  = aws_iam_role.otel_task_role_s3[0].id
+  count = var.task_definition_arn == null && var.task_role_arn == null && !(
+    var.supervisor_enabled && var.s3_config_bucket == null
+  ) ? 1 : 0
+  name = "S3ReadAccess"
+  role = aws_iam_role.otel_task_role_s3[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -208,11 +208,9 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null && !(
-    var.supervisor_enabled && var.s3_config_bucket == null
-  ) ? 1 : 0
-  name = "S3ReadAccess"
-  role = aws_iam_role.otel_task_role_s3[0].id
+  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  name  = "S3ReadAccess"
+  role  = aws_iam_role.otel_task_role_s3[0].id
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -4,7 +4,7 @@ variable "ecs_cluster_name" {
 }
 
 variable "config_source" {
-  description = "Reserved for UI compatibility. Only 's3' is supported. Omit when using the module directly."
+  description = "Reserved for UI compatibility. Keep this set to 's3'. Supervised mode uses embedded configs when S3 paths are omitted."
   type        = string
   default     = "s3"
   validation {
@@ -13,43 +13,82 @@ variable "config_source" {
   }
 }
 
+variable "image_mode" {
+  description = "Image mode. Collector mode uses the standard CDOT image and requires an S3 collector config. Supervised mode uses the supervised CDOT image and embedded configs unless S3 paths are provided."
+  type        = string
+  default     = "collector"
+
+  validation {
+    condition     = contains(["collector", "supervised"], var.image_mode)
+    error_message = "image_mode must be either 'collector' or 'supervised'."
+  }
+}
+
 variable "s3_config_bucket" {
-  description = "S3 bucket name containing the OpenTelemetry configuration file. Required when the module creates the task definition (task_definition_arn is null). Ignored in service-only mode (task_definition_arn set)."
+  description = "S3 bucket containing collector and optional Supervisor configurations. Required in collector mode. In supervised mode, omit it to use embedded configs. Ignored in service-only mode."
   type        = string
   default     = null
 
   validation {
-    condition     = var.task_definition_arn != null || var.s3_config_bucket != null
-    error_message = "s3_config_bucket is required when task_definition_arn is null (module creates the task definition)."
+    condition     = var.task_definition_arn != null || var.image_mode == "supervised" || try(trimspace(var.s3_config_bucket) != "", false)
+    error_message = "s3_config_bucket is required in collector mode when the module creates the task definition."
   }
 }
 
 variable "s3_config_key" {
-  description = "S3 object key (file path) for the configuration file. Example: configs/otel-config.yaml. Required when the module creates the task definition. Ignored in service-only mode."
+  description = "S3 object key for the collector configuration. Required in collector mode. In supervised mode, omit it to use the embedded collector config. Ignored in service-only mode."
   type        = string
   default     = null
 
   validation {
-    condition     = var.task_definition_arn != null || var.s3_config_key != null
-    error_message = "s3_config_key is required when task_definition_arn is null (module creates the task definition)."
+    condition     = var.task_definition_arn != null || var.image_mode == "supervised" || try(trimspace(var.s3_config_key) != "", false)
+    error_message = "s3_config_key is required in collector mode when the module creates the task definition."
   }
 }
 
+variable "s3_supervisor_config_key" {
+  description = "Optional S3 object key for the Supervisor configuration. Used only in supervised mode when s3_config_bucket is also set. When omitted, the embedded Supervisor config is used."
+  type        = string
+  default     = null
+}
+
 variable "image_version" {
-  description = "The Coralogix Open Telemetry Distribution Image Version/Tag. Required when module creates the task definition. Ignored in service-only mode."
+  description = "The standard CDOT image version used in collector mode. Required in collector mode when the module creates the task definition."
   type        = string
   default     = null
 
   validation {
-    condition     = var.task_definition_arn != null || var.image_version != null
-    error_message = "image_version is required when task_definition_arn is null (module creates the task definition)."
+    condition     = var.task_definition_arn != null || var.image_mode == "supervised" || try(trimspace(var.image_version) != "", false)
+    error_message = "image_version is required in collector mode when the module creates the task definition."
   }
 }
 
 variable "image" {
-  description = "The OpenTelemetry Collector Image to use. Should accept default unless advised by Coralogix support."
+  description = "The OpenTelemetry Collector image used in collector mode. Keep the default unless advised by Coralogix support."
   type        = string
   default     = "coralogixrepo/coralogix-otel-collector"
+}
+
+variable "supervised_image_repository" {
+  description = "The supervised CDOT image repository used in supervised mode."
+  type        = string
+  default     = "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot"
+
+  validation {
+    condition     = trimspace(var.supervised_image_repository) != ""
+    error_message = "supervised_image_repository must not be empty."
+  }
+}
+
+variable "supervised_image_version" {
+  description = "The supervised CDOT image version used in supervised mode."
+  type        = string
+  default     = "v0.10.0"
+
+  validation {
+    condition     = trimspace(var.supervised_image_version) != ""
+    error_message = "supervised_image_version must not be empty."
+  }
 }
 
 variable "memory" {
@@ -116,7 +155,7 @@ variable "api_key_secret_kms_key_arn" {
 }
 
 variable "task_execution_role_arn" {
-  description = "ARN of the task execution role. When not provided and the module creates the task definition, an auto-created role with S3 and optional Secrets Manager access is used. In service-only mode (task_definition_arn set), this must be explicitly null—roles live on the task definition, not the service."
+  description = "ARN of the task execution role. When not provided and the module creates the task definition, an auto-created role with the standard ECS execution policy and optional Secrets Manager access is used. In service-only mode, this must be null."
   type        = string
   default     = null
 
@@ -127,7 +166,7 @@ variable "task_execution_role_arn" {
 }
 
 variable "task_role_arn" {
-  description = "ARN of the task role (IAM role) that the container can assume. When not provided and the module creates the task definition, an auto-created role with S3 read permissions is used. In service-only mode (task_definition_arn set), this must be explicitly null—roles live on the task definition, not the service."
+  description = "ARN of the task role that the containers can assume. When an S3 config is selected and this is not provided, the module creates a role with S3 read permissions. In service-only mode, this must be null."
   type        = string
   default     = null
 

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -13,15 +13,10 @@ variable "config_source" {
   }
 }
 
-variable "image_mode" {
-  description = "Image mode. Collector mode uses the standard CDOT image and requires an S3 collector config. Supervised mode uses the supervised CDOT image and embedded configs unless S3 paths are provided."
-  type        = string
-  default     = "collector"
-
-  validation {
-    condition     = contains(["collector", "supervised"], var.image_mode)
-    error_message = "image_mode must be either 'collector' or 'supervised'."
-  }
+variable "supervisor_enabled" {
+  description = "Whether to run the Collector through the Supervisor. When enabled, the supervised CDOT image and embedded configs are used unless S3 paths are provided."
+  type        = bool
+  default     = false
 }
 
 variable "s3_config_bucket" {
@@ -30,7 +25,7 @@ variable "s3_config_bucket" {
   default     = null
 
   validation {
-    condition     = var.task_definition_arn != null || var.image_mode == "supervised" || try(trimspace(var.s3_config_bucket) != "", false)
+    condition     = var.task_definition_arn != null || var.supervisor_enabled || try(trimspace(var.s3_config_bucket) != "", false)
     error_message = "s3_config_bucket is required in collector mode when the module creates the task definition."
   }
 }
@@ -41,7 +36,7 @@ variable "s3_config_key" {
   default     = null
 
   validation {
-    condition     = var.task_definition_arn != null || var.image_mode == "supervised" || try(trimspace(var.s3_config_key) != "", false)
+    condition     = var.task_definition_arn != null || var.supervisor_enabled || try(trimspace(var.s3_config_key) != "", false)
     error_message = "s3_config_key is required in collector mode when the module creates the task definition."
   }
 }
@@ -58,7 +53,7 @@ variable "image_version" {
   default     = null
 
   validation {
-    condition     = var.task_definition_arn != null || var.image_mode == "supervised" || try(trimspace(var.image_version) != "", false)
+    condition     = var.task_definition_arn != null || var.supervisor_enabled || try(trimspace(var.image_version) != "", false)
     error_message = "image_version is required in collector mode when the module creates the task definition."
   }
 }

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -161,7 +161,7 @@ variable "task_execution_role_arn" {
 }
 
 variable "task_role_arn" {
-  description = "ARN of the task role that the containers can assume. When an S3 config is selected and this is not provided, the module creates a role with S3 read permissions. In service-only mode, this must be null."
+  description = "ARN of the task role that the containers can assume. When this is not provided, the module creates a role with S3 read permissions. In service-only mode, this must be null."
   type        = string
   default     = null
 

--- a/tests/ecs-ec2/README.md
+++ b/tests/ecs-ec2/README.md
@@ -4,7 +4,7 @@
 
 * ECS cluster on EC2
 * AWS profile or `AWS_DEFAULT_REGION`
-* S3 bucket with OTEL config (create via `resources/s3`)
+* S3 bucket with OTEL config for collector mode or S3 override tests (create via `resources/s3`)
 
 ## Setup
 
@@ -27,6 +27,7 @@
 terraform init
 terraform plan
 terraform apply
+./verify-supervised-mode.sh
 ```
 
 Expected: ECS Service `coralogix-otel-agent-<UUID>` runs as a Daemon; logs/traces/metrics sent to Coralogix.
@@ -35,6 +36,8 @@ Expected: ECS Service `coralogix-otel-agent-<UUID>` runs as a Daemon; logs/trace
 
 | Scenario | Var file | Prerequisite |
 |----------|----------|--------------|
+| Supervised + embedded configs | Default test variables | None |
+| Supervised + S3 overrides | Pass all three S3 variables | `resources/s3` |
 | 1. S3 + inline API key | `terraform.tfvars` | `resources/s3` |
 | 2. S3 + Secrets Manager (module auto-creates execution role) | `vars/example-secrets-manager.tfvars.template` | `resources/s3`, `resources/parameter-store` |
 | 3. Service-only (existing task definition) | `vars/example-service-only.tfvars.template` | Existing task definition ARN. Run `./verify-service-only-mode.sh` to assert no task definition or IAM resources are planned. |

--- a/tests/ecs-ec2/ecs-ec2.tf
+++ b/tests/ecs-ec2/ecs-ec2.tf
@@ -12,11 +12,14 @@ provider "aws" {
 }
 
 module "ecs-ec2" {
-  source           = "../../modules/ecs-ec2"
-  ecs_cluster_name = var.ecs_cluster_name
-  image            = var.image
-  image_version    = var.image_version
-  memory           = var.memory
+  source                      = "../../modules/ecs-ec2"
+  ecs_cluster_name            = var.ecs_cluster_name
+  image                       = var.image
+  image_version               = var.image_version
+  image_mode                  = var.image_mode
+  supervised_image_repository = var.supervised_image_repository
+  supervised_image_version    = var.supervised_image_version
+  memory                      = var.memory
 
   coralogix_region = var.coralogix_region
   custom_domain    = var.custom_domain
@@ -25,12 +28,13 @@ module "ecs-ec2" {
   api_key_secret_arn = var.api_key_secret_arn
   api_key            = var.api_key
 
-  s3_config_bucket = var.s3_config_bucket
-  s3_config_key    = var.s3_config_key
+  s3_config_bucket         = var.s3_config_bucket
+  s3_config_key            = var.s3_config_key
+  s3_supervisor_config_key = var.s3_supervisor_config_key
 
   task_execution_role_arn = var.task_execution_role_arn
   task_role_arn           = var.task_role_arn
-  task_definition_arn      = var.task_definition_arn
+  task_definition_arn     = var.task_definition_arn
 
   health_check_enabled  = var.health_check_enabled
   health_check_interval = var.health_check_interval

--- a/tests/ecs-ec2/ecs-ec2.tf
+++ b/tests/ecs-ec2/ecs-ec2.tf
@@ -16,7 +16,7 @@ module "ecs-ec2" {
   ecs_cluster_name            = var.ecs_cluster_name
   image                       = var.image
   image_version               = var.image_version
-  image_mode                  = var.image_mode
+  supervisor_enabled          = var.supervisor_enabled
   supervised_image_repository = var.supervised_image_repository
   supervised_image_version    = var.supervised_image_version
   memory                      = var.memory

--- a/tests/ecs-ec2/variables.tf
+++ b/tests/ecs-ec2/variables.tf
@@ -22,6 +22,24 @@ variable "image_version" {
   default     = "v0.5.10"
 }
 
+variable "image_mode" {
+  description = "Collector image mode to test"
+  type        = string
+  default     = "supervised"
+}
+
+variable "supervised_image_repository" {
+  description = "Repository for the supervised CDOT image"
+  type        = string
+  default     = "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot"
+}
+
+variable "supervised_image_version" {
+  description = "Version tag for the supervised CDOT image"
+  type        = string
+  default     = "v0.10.0"
+}
+
 variable "coralogix_region" {
   description = "Coralogix region for data ingestion"
   type        = string
@@ -54,15 +72,21 @@ variable "api_key" {
 }
 
 variable "s3_config_bucket" {
-  description = "S3 bucket name containing the configuration file. Required when task_definition_arn is null."
+  description = "S3 bucket containing optional collector and Supervisor config overrides"
   type        = string
-  default     = "placeholder-bucket"
+  default     = null
 }
 
 variable "s3_config_key" {
-  description = "S3 object key (file path) for the configuration file. Required when task_definition_arn is null."
+  description = "Optional S3 object key for the collector config"
   type        = string
-  default     = "configs/otel-config.yaml"
+  default     = null
+}
+
+variable "s3_supervisor_config_key" {
+  description = "Optional S3 object key for the Supervisor config"
+  type        = string
+  default     = null
 }
 
 variable "task_definition_arn" {

--- a/tests/ecs-ec2/variables.tf
+++ b/tests/ecs-ec2/variables.tf
@@ -22,10 +22,10 @@ variable "image_version" {
   default     = "v0.5.10"
 }
 
-variable "image_mode" {
-  description = "Collector image mode to test"
-  type        = string
-  default     = "supervised"
+variable "supervisor_enabled" {
+  description = "Whether to test Supervisor mode"
+  type        = bool
+  default     = true
 }
 
 variable "supervised_image_repository" {

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INLINE_PLAN="$TMP_DIR/inline.tfplan"
+INLINE_JSON="$TMP_DIR/inline.json"
+S3_PLAN="$TMP_DIR/s3.tfplan"
+S3_JSON="$TMP_DIR/s3.json"
+
+terraform plan -input=false -lock=false -var='health_check_enabled=true' -out="$INLINE_PLAN" >/dev/null
+terraform show -json "$INLINE_PLAN" > "$INLINE_JSON"
+
+TASK_ADDRESS='module.ecs-ec2.aws_ecs_task_definition.coralogix_otel_agent[0]'
+INLINE_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$INLINE_JSON")
+INLINE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$INLINE_TASK")
+
+jq -e '
+  any(.[];
+    .name == "config-loader"
+    and any(.environment[];
+      .name == "COLLECTOR_CONFIG"
+      and (.value | contains("receivers:\n  nop:"))
+      and (.value | contains("endpoint: \"localhost:13133\""))
+      and (.value | contains("traces:"))
+      and (.value | contains("metrics:"))
+      and (.value | contains("logs:"))
+    )
+    and any(.environment[]; .name == "SUPERVISOR_CONFIG" and (.value | contains("opamp/v1")))
+  )
+  and any(.[];
+    .name == "coralogix-otel-agent"
+    and .image == "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot:v0.10.0"
+    and .privileged == true
+    and .healthCheck.command == ["CMD", "/healthcheck"]
+    and any(.dependsOn[]; .containerName == "config-loader" and .condition == "SUCCESS")
+  )
+' <<< "$INLINE_CONTAINERS" >/dev/null
+
+jq -e '
+  [.resource_changes[]
+    | select(.address | contains("otel_task_role_s3"))
+    | select(.change.actions | index("create"))]
+  | length == 0
+' "$INLINE_JSON" >/dev/null
+
+terraform plan \
+  -input=false \
+  -lock=false \
+  -var='s3_config_bucket=placeholder-bucket' \
+  -var='s3_config_key=configs/collector.yaml' \
+  -var='s3_supervisor_config_key=configs/supervisor.yaml' \
+  -out="$S3_PLAN" >/dev/null
+terraform show -json "$S3_PLAN" > "$S3_JSON"
+
+jq -e '
+  any(.resource_changes[];
+    .address == "module.ecs-ec2.aws_iam_role.otel_task_role_s3[0]"
+    and (.change.actions | index("create"))
+  )
+' "$S3_JSON" >/dev/null
+
+S3_POLICY=$(jq -r '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == "module.ecs-ec2.aws_iam_role_policy.otel_task_role_s3_s3_policy[0]")
+  | .values.policy
+' "$S3_JSON")
+
+jq -e '
+  any(.Statement[];
+    (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
+    and .Resource == "arn:aws:s3:::placeholder-bucket/*"
+  )
+  and any(.Statement[];
+    .Action == ["s3:ListBucket"]
+    and .Resource == "arn:aws:s3:::placeholder-bucket"
+  )
+' <<< "$S3_POLICY" >/dev/null
+
+S3_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$S3_JSON")
+S3_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$S3_TASK")
+
+jq -e '
+  any(.[];
+    .name == "config-loader"
+    and any(.environment[]; .name == "S3_CONFIG_BUCKET" and .value == "placeholder-bucket")
+    and any(.environment[]; .name == "S3_CONFIG_KEY" and .value == "configs/collector.yaml")
+    and any(.environment[]; .name == "S3_SUPERVISOR_CONFIG_KEY" and .value == "configs/supervisor.yaml")
+    and (.command[0] | startswith("set -e\nif [ -n \"$S3_CONFIG_BUCKET\" ]"))
+  )
+' <<< "$S3_CONTAINERS" >/dev/null
+
+echo "[PASS] Supervised mode embeds configs by default and prefers configured S3 paths."

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -46,7 +46,7 @@ jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
-  | length == 0
+  | length == 2
 ' "$INLINE_JSON" >/dev/null
 
 terraform plan \

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -22,6 +22,7 @@ INLINE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$INLINE_TASK")
 jq -e '
   any(.[];
     .name == "config-loader"
+    and any(.environment[]; .name == "SUPERVISOR_ENABLED" and .value == "true")
     and any(.environment[];
       .name == "COLLECTOR_CONFIG"
       and (.value | contains("receivers:\n  nop:"))

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
+# Verifies that Supervisor mode embeds its default configurations and prefers S3 overrides.
+# Contract: Supervisor mode uses the supervised image, a NOP Collector bootstrap config,
+# and the embedded Supervisor config unless matching S3 paths are configured.
+#
+# Usage: ./verify-supervised-mode.sh
+#
+# Requires: terraform, jq
+
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -9,6 +20,12 @@ INLINE_JSON="$TMP_DIR/inline.json"
 S3_PLAN="$TMP_DIR/s3.tfplan"
 S3_JSON="$TMP_DIR/s3.json"
 
+fail() {
+  echo "[FAIL] $1" >&2
+  exit 1
+}
+
+echo "[INFO] Verifying Supervisor mode with embedded configurations..."
 terraform plan -input=false -lock=false -var='health_check_enabled=true' -out="$INLINE_PLAN" >/dev/null
 terraform show -json "$INLINE_PLAN" > "$INLINE_JSON"
 
@@ -19,7 +36,7 @@ INLINE_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
 ' "$INLINE_JSON")
 INLINE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$INLINE_TASK")
 
-jq -e '
+if ! jq -e '
   any(.[];
     .name == "config-loader"
     and any(.environment[]; .name == "SUPERVISOR_ENABLED" and .value == "true")
@@ -40,15 +57,20 @@ jq -e '
     and .healthCheck.command == ["CMD", "/healthcheck"]
     and any(.dependsOn[]; .containerName == "config-loader" and .condition == "SUCCESS")
   )
-' <<< "$INLINE_CONTAINERS" >/dev/null
+' <<< "$INLINE_CONTAINERS" >/dev/null; then
+  fail "Embedded Supervisor mode does not contain the expected NOP config, supervised image, or health check."
+fi
 
-jq -e '
+if ! jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
   | length == 2
-' "$INLINE_JSON" >/dev/null
+' "$INLINE_JSON" >/dev/null; then
+  fail "Embedded Supervisor mode does not create the expected task role and S3 policy."
+fi
 
+echo "[INFO] Verifying Supervisor mode with S3 configuration overrides..."
 terraform plan \
   -input=false \
   -lock=false \
@@ -58,12 +80,14 @@ terraform plan \
   -out="$S3_PLAN" >/dev/null
 terraform show -json "$S3_PLAN" > "$S3_JSON"
 
-jq -e '
+if ! jq -e '
   any(.resource_changes[];
     .address == "module.ecs-ec2.aws_iam_role.otel_task_role_s3[0]"
     and (.change.actions | index("create"))
   )
-' "$S3_JSON" >/dev/null
+' "$S3_JSON" >/dev/null; then
+  fail "Supervisor mode with S3 overrides does not create the expected task role."
+fi
 
 S3_POLICY=$(jq -r '
   .planned_values.root_module.child_modules[].resources[]
@@ -71,7 +95,7 @@ S3_POLICY=$(jq -r '
   | .values.policy
 ' "$S3_JSON")
 
-jq -e '
+if ! jq -e '
   any(.Statement[];
     (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
     and .Resource == "arn:aws:s3:::placeholder-bucket/*"
@@ -80,7 +104,9 @@ jq -e '
     .Action == ["s3:ListBucket"]
     and .Resource == "arn:aws:s3:::placeholder-bucket"
   )
-' <<< "$S3_POLICY" >/dev/null
+' <<< "$S3_POLICY" >/dev/null; then
+  fail "The task role policy does not grant the expected read access to the configured S3 bucket."
+fi
 
 S3_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
   .planned_values.root_module.child_modules[].resources[]
@@ -88,7 +114,7 @@ S3_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
 ' "$S3_JSON")
 S3_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$S3_TASK")
 
-jq -e '
+if ! jq -e '
   any(.[];
     .name == "config-loader"
     and any(.environment[]; .name == "S3_CONFIG_BUCKET" and .value == "placeholder-bucket")
@@ -96,6 +122,8 @@ jq -e '
     and any(.environment[]; .name == "S3_SUPERVISOR_CONFIG_KEY" and .value == "configs/supervisor.yaml")
     and (.command[0] | startswith("set -e\nif [ -n \"$S3_CONFIG_BUCKET\" ]"))
   )
-' <<< "$S3_CONTAINERS" >/dev/null
+' <<< "$S3_CONTAINERS" >/dev/null; then
+  fail "The config loader does not prefer the configured S3 Collector and Supervisor paths."
+fi
 
 echo "[PASS] Supervised mode embeds configs by default and prefers configured S3 paths."

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -78,9 +78,9 @@ if ! jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
-  | length == 2
+  | length == 1
 ' "$INLINE_JSON" >/dev/null; then
-  fail "Embedded Supervisor mode does not create the expected task role and S3 policy."
+  fail "Embedded Supervisor mode does not create the expected task role without an S3 policy."
 fi
 
 echo "[INFO] Verifying Supervisor mode with S3 configuration overrides..."

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -78,9 +78,9 @@ if ! jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
-  | length == 1
+  | length == 2
 ' "$INLINE_JSON" >/dev/null; then
-  fail "Embedded Supervisor mode does not create the expected task role without an S3 policy."
+  fail "Embedded Supervisor mode does not create the expected task role and S3 policy."
 fi
 
 echo "[INFO] Verifying Supervisor mode with S3 configuration overrides..."

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Verifies that Supervisor mode embeds its default configurations and prefers S3 overrides.
 # Contract: Supervisor mode uses the supervised image, a NOP Collector bootstrap config,
-# and the embedded Supervisor config unless matching S3 paths are configured.
+# and the embedded Supervisor config unless matching S3 paths are configured. Collector
+# mode keeps the custom image entrypoint and receives its configuration through arguments.
 #
 # Usage: ./verify-supervised-mode.sh
 #
@@ -19,6 +20,8 @@ INLINE_PLAN="$TMP_DIR/inline.tfplan"
 INLINE_JSON="$TMP_DIR/inline.json"
 S3_PLAN="$TMP_DIR/s3.tfplan"
 S3_JSON="$TMP_DIR/s3.json"
+COLLECTOR_PLAN="$TMP_DIR/collector.tfplan"
+COLLECTOR_JSON="$TMP_DIR/collector.json"
 
 fail() {
   echo "[FAIL] $1" >&2
@@ -39,7 +42,6 @@ INLINE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$INLINE_TASK")
 if ! jq -e '
   any(.[];
     .name == "config-loader"
-    and any(.environment[]; .name == "SUPERVISOR_ENABLED" and .value == "true")
     and any(.environment[];
       .name == "COLLECTOR_CONFIG"
       and (.value | contains("receivers:\n  nop:"))
@@ -48,13 +50,24 @@ if ! jq -e '
       and (.value | contains("metrics:"))
       and (.value | contains("logs:"))
     )
-    and any(.environment[]; .name == "SUPERVISOR_CONFIG" and (.value | contains("opamp/v1")))
+    and any(.environment[];
+      .name == "SUPERVISOR_CONFIG"
+      and (.value | contains("opamp/v1"))
+      and (.value | contains("- /otel-config/collector-config.yaml"))
+    )
+    and any(.mountPoints[]; .containerPath == "/otel-config")
   )
   and any(.[];
     .name == "coralogix-otel-agent"
     and .image == "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot:v0.10.0"
     and .privileged == true
+    and (has("entryPoint") | not)
+    and .command == ["--config", "/otel-config/supervisor.yaml"]
     and .healthCheck.command == ["CMD", "/healthcheck"]
+    and any(.mountPoints[];
+      .containerPath == "/otel-config"
+      and .readOnly == true
+    )
     and any(.dependsOn[]; .containerName == "config-loader" and .condition == "SUCCESS")
   )
 ' <<< "$INLINE_CONTAINERS" >/dev/null; then
@@ -120,10 +133,46 @@ if ! jq -e '
     and any(.environment[]; .name == "S3_CONFIG_BUCKET" and .value == "placeholder-bucket")
     and any(.environment[]; .name == "S3_CONFIG_KEY" and .value == "configs/collector.yaml")
     and any(.environment[]; .name == "S3_SUPERVISOR_CONFIG_KEY" and .value == "configs/supervisor.yaml")
-    and (.command[0] | startswith("set -e\nif [ -n \"$S3_CONFIG_BUCKET\" ]"))
+    and (.command[0] | contains("/otel-config/collector-config.yaml"))
+    and (.command[0] | contains("/otel-config/supervisor.yaml"))
   )
 ' <<< "$S3_CONTAINERS" >/dev/null; then
   fail "The config loader does not prefer the configured S3 Collector and Supervisor paths."
+fi
+
+echo "[INFO] Verifying collector mode keeps the image entrypoint..."
+terraform plan \
+  -input=false \
+  -lock=false \
+  -var='supervisor_enabled=false' \
+  -var='image=example.com/custom-collector' \
+  -var='image_version=latest' \
+  -var='s3_config_bucket=placeholder-bucket' \
+  -var='s3_config_key=configs/collector.yaml' \
+  -out="$COLLECTOR_PLAN" >/dev/null
+terraform show -json "$COLLECTOR_PLAN" > "$COLLECTOR_JSON"
+
+COLLECTOR_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$COLLECTOR_JSON")
+COLLECTOR_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$COLLECTOR_TASK")
+
+if ! jq -e '
+  length == 2
+  and any(.[];
+    .name == "config-loader"
+    and any(.environment[]; .name == "SUPERVISOR_ENABLED" and .value == "false")
+  )
+  and any(.[];
+    .name == "coralogix-otel-agent"
+    and .image == "example.com/custom-collector:latest"
+    and (has("entryPoint") | not)
+    and .command == ["--config", "s3://placeholder-bucket.s3.us-east-1.amazonaws.com/configs/collector.yaml"]
+    and any(.dependsOn[]; .containerName == "config-loader" and .condition == "SUCCESS")
+  )
+' <<< "$COLLECTOR_CONTAINERS" >/dev/null; then
+  fail "Collector mode does not preserve the image entrypoint and S3 configuration argument."
 fi
 
 echo "[PASS] Supervised mode embeds configs by default and prefers configured S3 paths."


### PR DESCRIPTION
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> 

Fixes CX-48445.

Adds support for Supervisor mode with the nop config in the ecs-ec2 terraform module.

# How Has This Been Tested?

Ran smoke tests in a real cluster.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)