### PR TITLE
feat(ecs-ec2): add fallback configuration support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,30 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     outputs:
-      packages: ${{ env.packages }}
+      packages: ${{ steps.get-changed-packages.outputs.packages }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
       - name: Get changed packages
         id: get-changed-packages
         run: |
-          export PACKAGES=$(git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha || 'origin/master' }} ${{ github.sha }} modules/ | xargs -n1 dirname | sed -r 's/modules\/([^\/]+).*$/modules\/\1/g' | xargs -n1 basename | sort | uniq | jq -rcnR '[inputs]')
-          echo "packages=$PACKAGES" >> $GITHUB_ENV
+          set -euo pipefail
+          PACKAGES=$(
+            git diff --name-only --diff-filter=d \
+              "${{ github.event.pull_request.base.sha || 'origin/master' }}" "${{ github.sha }}" -- modules/ \
+              | xargs -r -n1 dirname \
+              | sed -r 's|modules/([^/]+).*$|modules/\1|g' \
+              | xargs -r -n1 basename \
+              | sort -u \
+              | jq -rcnR '[inputs]'
+          )
+          if [[ "$PACKAGES" == "[]" ]]; then
+            echo "No changed modules under modules/; refusing empty matrix." >&2
+            exit 1
+          fi
+          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
 
   validate:
     name: Validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.6.0
+
+#### **ecs-ec2**
+### 💡 Enhancements 💡
+- Added `initial_fallback_configs` for Supervisor mode. When set, the embedded Supervisor config receives `agent.initial_fallback_configs` with the provided `s3://` URLs. Requires `s3_config_bucket`.
+
 ## v4.5.0
 
 #### **ecs-ec2**

--- a/examples/ecs-ec2/README.md
+++ b/examples/ecs-ec2/README.md
@@ -52,10 +52,31 @@ Supervisor mode uses the supervised image and embeds the default Supervisor and 
 module "otel_ecs_ec2_coralogix" {
   source = "coralogix/aws/coralogix//modules/ecs-ec2"
 
-  ecs_cluster_name    = "my-ecs-cluster"
+  ecs_cluster_name   = "my-ecs-cluster"
   supervisor_enabled = true
-  coralogix_region    = "EU1"
-  api_key             = "your-coralogix-api-key"
+  coralogix_region   = "EU1"
+  api_key            = "your-coralogix-api-key"
+}
+```
+
+### Supervisor with Initial Fallback Configurations
+
+When OpAMP remote config is unavailable, the Supervisor can fall back to collector configs hosted in S3. Provide full `s3://` object URLs and set `s3_config_bucket` so the auto-created task role can read them. This applies only to the embedded Supervisor config.
+
+```hcl
+module "otel_ecs_ec2_coralogix" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name   = "my-ecs-cluster"
+  supervisor_enabled = true
+  coralogix_region   = "EU1"
+  api_key            = "your-coralogix-api-key"
+
+  s3_config_bucket = "my-otel-config-bucket"
+  initial_fallback_configs = [
+    "s3://my-otel-config-bucket.s3.eu-north-1.amazonaws.com/<ACCOUNT_ID>/<GROUP_NAME>/<COLLECTOR_VERSION>/<REMOTE_CONFIG_NAME>/config.yaml",
+    "s3://my-otel-config-bucket.s3.eu-north-1.amazonaws.com/<ACCOUNT_ID>/<GROUP_NAME>/EMPTY_VERSION/<REMOTE_CONFIG_NAME>/config.yaml",
+  ]
 }
 ```
 

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -14,6 +14,8 @@ In `collector` mode, the module loads the OpenTelemetry configuration from S3. T
 
 In `supervised` mode, the module uses the supervised image, embeds a NOP Collector bootstrap config and the default Supervisor config. Set `s3_config_bucket` with `s3_config_key` or `s3_supervisor_config_key` to override either embedded config from S3. An S3 path always takes priority over the matching embedded config.
 
+`initial_fallback_configs` is a list of full `s3://` object URLs injected into the embedded Supervisor config as `agent.initial_fallback_configs`. The default is an empty list (no startup fallback). This applies only to the embedded Supervisor configuration; an S3-provided Supervisor configuration is used as-is. When the list is non-empty, `s3_config_bucket` is required and every fallback URL must reference that bucket so the auto-created task role can read the objects. When `task_role_arn` is provided, that custom role must grant `s3:GetObject` access to the fallback objects.
+
 The module passes these environment variables to the collector:
 - `CORALOGIX_DOMAIN` – region-specific domain (from coralogix_region)
 - `CORALOGIX_PRIVATE_KEY` – your API key
@@ -43,10 +45,28 @@ For Supervisor mode with embedded configs:
 module "ecs-ec2" {
   source = "coralogix/aws/coralogix//modules/ecs-ec2"
 
-  ecs_cluster_name     = "my-cluster"
+  ecs_cluster_name   = "my-cluster"
   supervisor_enabled = true
-  coralogix_region     = "EU1"
-  api_key              = "your-coralogix-api-key"
+  coralogix_region   = "EU1"
+  api_key            = "your-coralogix-api-key"
+}
+```
+
+For Supervisor mode with initial fallback configurations:
+
+```terraform
+module "ecs-ec2" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name   = "my-cluster"
+  supervisor_enabled = true
+  coralogix_region   = "EU1"
+  api_key            = "your-coralogix-api-key"
+
+  s3_config_bucket = "my-otel-config-bucket"
+  initial_fallback_configs = [
+    "s3://my-otel-config-bucket.s3.eu-north-1.amazonaws.com/<ACCOUNT_ID>/<GROUP_NAME>/<COLLECTOR_VERSION>/<REMOTE_CONFIG_NAME>/config.yaml",
+  ]
 }
 ```
 
@@ -110,9 +130,10 @@ You can control health checks using:
 | supervised_image_version | Supervised Coralogix Otel Collector image version/tag | `string` | `"v0.10.0"` | no |
 | coralogix_region | Coralogix region: EU1, EU2, AP1, AP2, AP3, US1, US2, custom | `string` | `null` | yes* |
 | api_key | Send-Your-Data API key | `string` | `null` | yes** |
-| s3_config_bucket | S3 bucket containing collector and optional Supervisor configs | `string` | `null` | yes* |
+| s3_config_bucket | S3 bucket containing collector and optional Supervisor configs. Also required when `initial_fallback_configs` is set. | `string` | `null` | yes* |
 | s3_config_key | S3 object key for the collector config | `string` | `null` | yes* |
 | s3_supervisor_config_key | Optional S3 object key for the Supervisor config | `string` | `null` | no |
+| initial_fallback_configs | Initial Supervisor fallback configuration URLs (`s3://` paths). Applied only to the embedded Supervisor config. Requires `s3_config_bucket` when non-empty. | `list(string)` | `[]` | no |
 | config_source | Reserved for UI compatibility. Keep set to `s3`. | `string` | `"s3"` | no |
 | image | OTEL Collector image | `string` | `"coralogixrepo/coralogix-otel-collector"` | no |
 | memory | Task memory (MiB) | `number` | `256` | no |

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -17,8 +17,8 @@ locals {
   s3_config_bucket         = var.s3_config_bucket == null ? "" : var.s3_config_bucket
   s3_config_key            = var.s3_config_key == null ? "" : var.s3_config_key
   s3_supervisor_config_key = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
-  # Format matching CloudFormation: initial_fallback_configs: [url1, url2] or []
-  initial_fallback_configs = length(var.initial_fallback_configs) == 0 ? "[]" : "[${join(", ", var.initial_fallback_configs)}]"
+  # JSON array is valid YAML and correctly escapes commas/special chars in URLs.
+  initial_fallback_configs = jsonencode(var.initial_fallback_configs)
   execution_role_arn       = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
   task_role_arn            = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -17,6 +17,8 @@ locals {
   s3_config_bucket         = var.s3_config_bucket == null ? "" : var.s3_config_bucket
   s3_config_key            = var.s3_config_key == null ? "" : var.s3_config_key
   s3_supervisor_config_key = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
+  # Format matching CloudFormation: initial_fallback_configs: [url1, url2] or []
+  initial_fallback_configs = length(var.initial_fallback_configs) == 0 ? "[]" : "[${join(", ", var.initial_fallback_configs)}]"
   execution_role_arn       = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
   task_role_arn            = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 
@@ -71,6 +73,7 @@ locals {
       passthrough_logs: true
       config_files:
         - /otel-config/collector-config.yaml
+      initial_fallback_configs: ${local.initial_fallback_configs}
 
     storage:
       directory: /etc/otelcol-contrib/supervisor-data/

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -47,6 +47,29 @@ variable "s3_supervisor_config_key" {
   default     = null
 }
 
+variable "initial_fallback_configs" {
+  description = "Initial Supervisor fallback configuration URLs for the collector agent (full s3:// object paths). Applied only to the embedded Supervisor config; an S3-provided Supervisor config is used as-is. Requires s3_config_bucket when non-empty so the auto-created task role can read those objects. Ignored in service-only mode."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.initial_fallback_configs) == 0 || var.task_definition_arn != null || var.supervisor_enabled
+    error_message = "initial_fallback_configs requires supervisor_enabled = true when the module creates the task definition."
+  }
+
+  validation {
+    condition     = length(var.initial_fallback_configs) == 0 || var.task_definition_arn != null || try(trimspace(var.s3_config_bucket) != "", false)
+    error_message = "s3_config_bucket is required when initial_fallback_configs is set."
+  }
+
+  validation {
+    condition = alltrue([
+      for url in var.initial_fallback_configs : can(regex("^s3://.+", trimspace(url)))
+    ])
+    error_message = "Each initial_fallback_configs entry must be a non-empty s3:// URL."
+  }
+}
+
 variable "image_version" {
   description = "The standard CDOT image version used in collector mode. Required in collector mode when the module creates the task definition."
   type        = string

--- a/tests/ecs-ec2/ecs-ec2.tf
+++ b/tests/ecs-ec2/ecs-ec2.tf
@@ -31,6 +31,7 @@ module "ecs-ec2" {
   s3_config_bucket         = var.s3_config_bucket
   s3_config_key            = var.s3_config_key
   s3_supervisor_config_key = var.s3_supervisor_config_key
+  initial_fallback_configs = var.initial_fallback_configs
 
   task_execution_role_arn = var.task_execution_role_arn
   task_role_arn           = var.task_role_arn

--- a/tests/ecs-ec2/variables.tf
+++ b/tests/ecs-ec2/variables.tf
@@ -89,6 +89,12 @@ variable "s3_supervisor_config_key" {
   default     = null
 }
 
+variable "initial_fallback_configs" {
+  description = "Initial Supervisor fallback configuration URLs"
+  type        = list(string)
+  default     = []
+}
+
 variable "task_definition_arn" {
   description = "Existing task definition ARN. When set, service-only mode: module creates only the ECS service."
   type        = string

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -54,6 +54,7 @@ if ! jq -e '
       .name == "SUPERVISOR_CONFIG"
       and (.value | contains("opamp/v1"))
       and (.value | contains("- /otel-config/collector-config.yaml"))
+      and (.value | contains("initial_fallback_configs: []"))
     )
     and any(.mountPoints[]; .containerPath == "/otel-config")
   )
@@ -140,6 +141,52 @@ if ! jq -e '
   fail "The config loader does not prefer the configured S3 Collector and Supervisor paths."
 fi
 
+echo "[INFO] Verifying Supervisor mode with initial fallback configurations..."
+FALLBACK_PLAN="$TMP_DIR/fallback.tfplan"
+FALLBACK_JSON="$TMP_DIR/fallback.json"
+FALLBACK_URL="s3://placeholder-bucket.s3.us-east-1.amazonaws.com/account/group/EMPTY_VERSION/remote/config.yaml"
+
+terraform plan \
+  -input=false \
+  -lock=false \
+  -var='s3_config_bucket=placeholder-bucket' \
+  -var="initial_fallback_configs=[\"$FALLBACK_URL\"]" \
+  -out="$FALLBACK_PLAN" >/dev/null
+terraform show -json "$FALLBACK_PLAN" > "$FALLBACK_JSON"
+
+FALLBACK_TASK=$(jq -c --arg address "$TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$FALLBACK_JSON")
+FALLBACK_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$FALLBACK_TASK")
+
+if ! jq -e --arg url "$FALLBACK_URL" '
+  any(.[];
+    .name == "config-loader"
+    and any(.environment[];
+      .name == "SUPERVISOR_CONFIG"
+      and (.value | contains("initial_fallback_configs: [" + $url + "]"))
+    )
+  )
+' <<< "$FALLBACK_CONTAINERS" >/dev/null; then
+  fail "Supervisor mode with initial_fallback_configs does not embed the expected fallback URLs."
+fi
+
+FALLBACK_POLICY=$(jq -r '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == "module.ecs-ec2.aws_iam_role_policy.otel_task_role_s3_s3_policy[0]")
+  | .values.policy
+' "$FALLBACK_JSON")
+
+if ! jq -e '
+  any(.Statement[];
+    (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
+    and .Resource == "arn:aws:s3:::placeholder-bucket/*"
+  )
+' <<< "$FALLBACK_POLICY" >/dev/null; then
+  fail "initial_fallback_configs does not grant the expected S3 read access via s3_config_bucket."
+fi
+
 echo "[INFO] Verifying collector mode keeps the image entrypoint..."
 terraform plan \
   -input=false \
@@ -175,4 +222,4 @@ if ! jq -e '
   fail "Collector mode does not preserve the image entrypoint and S3 configuration argument."
 fi
 
-echo "[PASS] Supervised mode embeds configs by default and prefers configured S3 paths."
+echo "[PASS] Supervised mode embeds configs by default, supports initial_fallback_configs, and prefers configured S3 paths."

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -165,7 +165,8 @@ if ! jq -e --arg url "$FALLBACK_URL" '
     .name == "config-loader"
     and any(.environment[];
       .name == "SUPERVISOR_CONFIG"
-      and (.value | contains("initial_fallback_configs: [" + $url + "]"))
+      and (.value | contains("initial_fallback_configs:"))
+      and (.value | contains($url))
     )
   )
 ' <<< "$FALLBACK_CONTAINERS" >/dev/null; then


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> 

Fixes CX-49286.

This PR adds support for the initial fallback configuration setting for the Supervisor in the ecs-ec2 module.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Ran a smoke test and updated the verification script.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)