### PR TITLE
feat: s3-archive – add enforce_https option to deny non-HTTPS access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.7.0
+
+#### **s3-archive**
+### 💡 Enhancements 💡
+- Added `enforce_https` variable (default `true`) that appends an `AllowSSLRequestsOnly` statement to the logs and metrics archive bucket policies, denying any request made with `aws:SecureTransport = false`. Set it to `false` to keep the previous policies unchanged.
+
 ## v4.6.0
 
 #### **ecs-ec2**

--- a/modules/provisioning/s3-archive/README.md
+++ b/modules/provisioning/s3-archive/README.md
@@ -28,6 +28,7 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 | metrics_bucket_force_destroy | enable force destroy to the metrics S3 bucekt, to not allow delete if there is files in the bucket | `bool` | false | |
 | logs_kms_arn |  The arn of your kms for the logs bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |
 | metrics_kms_arn | The arn of your kms for the metrics bucket , Note: make sure that the kms is in the same region as your bucket | `string` | n/a | |
+| enforce_https | If true, add a bucket policy statement that denies all non-HTTPS requests (`aws:SecureTransport = false`) on the archive buckets | `bool` | true | |
 
 ## Outputs
 

--- a/modules/provisioning/s3-archive/main.tf
+++ b/modules/provisioning/s3-archive/main.tf
@@ -40,7 +40,7 @@ resource "aws_s3_bucket_policy" "logs_bucket_policy" {
   bucket = aws_s3_bucket.logs_bucket_name[count.index].id
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
         Effect = "Allow"
         Principal = {
@@ -62,7 +62,24 @@ resource "aws_s3_bucket_policy" "logs_bucket_policy" {
           "${aws_s3_bucket.logs_bucket_name[count.index].arn}/*",
         ]
       }
-    ]
+      ],
+      var.enforce_https ? [
+        {
+          Sid       = "AllowSSLRequestsOnly"
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource = [
+            aws_s3_bucket.logs_bucket_name[count.index].arn,
+            "${aws_s3_bucket.logs_bucket_name[count.index].arn}/*",
+          ]
+          Condition = {
+            Bool = {
+              "aws:SecureTransport" = "false"
+            }
+          }
+        }
+    ] : [])
   })
 }
 
@@ -83,7 +100,7 @@ resource "aws_s3_bucket_policy" "metrics_bucket_policy" {
   bucket = aws_s3_bucket.metrics_bucket_name[count.index].id
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
+    Statement = concat([
       {
         Effect = "Allow"
         Principal = {
@@ -105,7 +122,24 @@ resource "aws_s3_bucket_policy" "metrics_bucket_policy" {
           "${aws_s3_bucket.metrics_bucket_name[count.index].arn}/*",
         ]
       }
-    ]
+      ],
+      var.enforce_https ? [
+        {
+          Sid       = "AllowSSLRequestsOnly"
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource = [
+            aws_s3_bucket.metrics_bucket_name[count.index].arn,
+            "${aws_s3_bucket.metrics_bucket_name[count.index].arn}/*",
+          ]
+          Condition = {
+            Bool = {
+              "aws:SecureTransport" = "false"
+            }
+          }
+        }
+    ] : [])
   })
 }
 

--- a/modules/provisioning/s3-archive/variables.tf
+++ b/modules/provisioning/s3-archive/variables.tf
@@ -82,4 +82,9 @@ variable "aws_role_region" {
     "ap-southeast-3" = "ap3"
   }
 }
-  
+
+variable "enforce_https" {
+  type        = bool
+  description = "If true, add a bucket policy statement that denies all non-HTTPS requests (aws:SecureTransport = false) on the archive buckets."
+  default     = true
+}


### PR DESCRIPTION
## What
Adds an `enforce_https` variable (default `true`) to the `provisioning/s3-archive` module. When enabled it appends an `AllowSSLRequestsOnly` `Deny` statement (`aws:SecureTransport = false`) to the logs and metrics archive bucket policies, so access to those buckets must use HTTPS (data encrypted in transit).

## Why
The module hardcodes its bucket policy, and S3 allows only one bucket policy per bucket, so consumers can't add an HTTPS-only deny themselves. This deny is an AWS best practice ([Restricting access to Amazon S3 using HTTPS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html)) and is required by common compliance controls (e.g. SOC 2 / Vanta "S3 buckets allow only HTTPS traffic").

## Notes
- Default `true` (secure by default). It only denies non-HTTPS requests, which the Coralogix archive role never uses, so it's non-disruptive; existing users pick up the deny on next apply. Set `enforce_https = false` to opt out.
- No change to the existing Coralogix-role grant (statements are merged via `concat`).
- `terraform validate` passes; the module README inputs table is updated.

Happy to flip the default to `false` (opt-in) if you'd rather avoid any behavior change for existing users.
