### PR TITLE
feat(ecs-ec2): implement profiling support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,3 +131,10 @@ jobs:
           cd "tests/ecs-ec2"
           chmod +x verify-supervised-mode.sh
           ./verify-supervised-mode.sh
+
+      - if: ${{ github.event.pull_request.head.repo.full_name == github.repository && matrix.package == 'ecs-ec2' }}
+        name: Verify profiling mode configs and permissions
+        run: |
+          cd "tests/ecs-ec2"
+          chmod +x verify-profiling-mode.sh
+          ./verify-profiling-mode.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added optional profiling support with `profiling_enabled`, a separate profiling daemon service, profiling S3 config overrides, and `profiling_initial_fallback_configs`.
 - Profiling follows `supervisor_enabled`: collector mode requires profiling S3 paths; supervised mode embeds a NOP bootstrap and profiling Supervisor config with `service.profilesSupport`.
 - Default `supervised_image_version` is now `v0.11.0`.
-- The auto-created task role is created only when S3 access is needed, and its policy includes the profiling bucket when profiling S3 paths are set.
+- The auto-created task role policy includes the profiling bucket when profiling S3 paths are set.
 
 ## v4.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 💡 Enhancements 💡
 - Added optional profiling support with `profiling_enabled`, a separate profiling daemon service, profiling S3 config overrides, and `profiling_initial_fallback_configs`.
 - Profiling follows `supervisor_enabled`: collector mode requires profiling S3 paths; supervised mode embeds a NOP bootstrap and profiling Supervisor config with `service.profilesSupport`.
+- When Supervisor is enabled, all deployed agents run with `service.profilesSupport`, even when `profiling_enabled = false`. This allows the usage of profiling components via Fleet Management or S3 configuration without redeploying the ECS service.
 - Default `supervised_image_version` is now `v0.11.0`.
 - The auto-created task role policy includes the profiling bucket when profiling S3 paths are set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v4.8.0
+
+#### **ecs-ec2**
+### 💡 Enhancements 💡
+- Added optional profiling support with `profiling_enabled`, a separate profiling daemon service, profiling S3 config overrides, and `profiling_initial_fallback_configs`.
+- Profiling follows `supervisor_enabled`: collector mode requires profiling S3 paths; supervised mode embeds a NOP bootstrap and profiling Supervisor config with `service.profilesSupport`.
+- Default `supervised_image_version` is now `v0.11.0`.
+- The auto-created task role is created only when S3 access is needed, and its policy includes the profiling bucket when profiling S3 paths are set.
+
 ## v4.7.0
 
 #### **s3-archive**

--- a/examples/ecs-ec2/README.md
+++ b/examples/ecs-ec2/README.md
@@ -82,6 +82,8 @@ module "otel_ecs_ec2_coralogix" {
 
 ### Profiling in Collector Mode
 
+Upload the included [`profiling-config.yaml`](./profiling-config.yaml) file to S3. Set `profiling_s3_config_key` to its object key.
+
 ```hcl
 module "otel_ecs_ec2_coralogix" {
   source = "coralogix/aws/coralogix//modules/ecs-ec2"
@@ -100,6 +102,8 @@ module "otel_ecs_ec2_coralogix" {
 ```
 
 ### Profiling in Supervisor Mode
+
+The profiling Supervisor starts with a NOP configuration. After deployment, assign the included [`profiling-config.yaml`](./profiling-config.yaml) file to the profiling agent through Coralogix remote configuration.
 
 ```hcl
 module "otel_ecs_ec2_coralogix" {

--- a/examples/ecs-ec2/README.md
+++ b/examples/ecs-ec2/README.md
@@ -80,6 +80,39 @@ module "otel_ecs_ec2_coralogix" {
 }
 ```
 
+### Profiling in Collector Mode
+
+```hcl
+module "otel_ecs_ec2_coralogix" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name  = "my-ecs-cluster"
+  image_version     = "v0.5.10"
+  coralogix_region  = "EU1"
+  api_key           = "your-coralogix-api-key"
+  s3_config_bucket  = "my-otel-config-bucket"
+  s3_config_key     = "configs/otel-config.yaml"
+
+  profiling_enabled          = true
+  profiling_s3_config_bucket = "my-otel-config-bucket"
+  profiling_s3_config_key    = "configs/profiling-config.yaml"
+}
+```
+
+### Profiling in Supervisor Mode
+
+```hcl
+module "otel_ecs_ec2_coralogix" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name   = "my-ecs-cluster"
+  supervisor_enabled = true
+  coralogix_region   = "EU1"
+  api_key            = "your-coralogix-api-key"
+  profiling_enabled  = true
+}
+```
+
 ### Using Secrets Manager for API Key
 
 The module auto-creates an execution role with the standard ECS execution policy and Secrets Manager access when `task_execution_role_arn` is not provided. Runtime S3 access is granted through the task role:
@@ -137,7 +170,7 @@ module "otel_ecs_ec2_coralogix" {
 }
 ```
 
-**Note**: When providing a custom `task_role_arn`, ensure it has `s3:GetObject`, `s3:GetObjectVersion`, and `s3:ListBucket` permissions for the configuration bucket, as the config-loader container accesses S3 at runtime.
+**Note**: When providing a custom `task_role_arn`, ensure it has `s3:GetObject`, `s3:GetObjectVersion`, and `s3:ListBucket` permissions for the configuration bucket, as the config-loader container accesses S3 at runtime. When profiling uses a separate S3 bucket, grant the same permissions for that bucket as well.
 
 ## IAM Role Management
 

--- a/examples/ecs-ec2/ecs-ec2.tf
+++ b/examples/ecs-ec2/ecs-ec2.tf
@@ -1,13 +1,13 @@
 module "otel_ecs_ec2_coralogix" {
   source = "coralogix/aws/coralogix//modules/ecs-ec2"
 
-  ecs_cluster_name      = var.ecs_cluster_name
-  image_version         = var.image_version
-  coralogix_region      = var.coralogix_region
-  api_key               = var.api_key
-  s3_config_bucket      = var.s3_config_bucket
-  s3_config_key         = var.s3_config_key
-  health_check_enabled  = var.health_check_enabled
-  memory                = var.memory
-  tags                  = var.tags
+  ecs_cluster_name     = var.ecs_cluster_name
+  image_version        = var.image_version
+  coralogix_region     = var.coralogix_region
+  api_key              = var.api_key
+  s3_config_bucket     = var.s3_config_bucket
+  s3_config_key        = var.s3_config_key
+  health_check_enabled = var.health_check_enabled
+  memory               = var.memory
+  tags                 = var.tags
 }

--- a/examples/ecs-ec2/profiling-config.yaml
+++ b/examples/ecs-ec2/profiling-config.yaml
@@ -1,0 +1,30 @@
+receivers:
+  profiling:
+    samples_per_second: 20
+    reporter_interval: 5s
+    monitor_interval: 5s
+    probabilistic_interval: 1m
+    probabilistic_threshold: 100
+    tracers: all
+
+exporters:
+  coralogix:
+    domain: "${CORALOGIX_DOMAIN}"
+    private_key: "${CORALOGIX_PRIVATE_KEY}"
+    application_name: "myapplication"
+    subsystem_name: "profiler"
+    application_name_attributes:
+      - "aws.ecs.cluster"
+      - "aws.ecs.task.definition.family"
+    subsystem_name_attributes:
+      - "aws.ecs.container.name"
+      - "aws.ecs.docker.name"
+      - "docker.name"
+    timeout: 30s
+  debug: {}
+
+service:
+  pipelines:
+    profiles:
+      receivers: [profiling]
+      exporters: [coralogix, debug]

--- a/examples/ecs-ec2/profiling-config.yaml
+++ b/examples/ecs-ec2/profiling-config.yaml
@@ -23,7 +23,12 @@ exporters:
     timeout: 30s
   debug: {}
 
+extensions:
+  health_check:
+    endpoint: "localhost:13133"
+
 service:
+  extensions: [health_check]
   pipelines:
     profiles:
       receivers: [profiling]

--- a/modules/ecs-ec2-windows/main.tf
+++ b/modules/ecs-ec2-windows/main.tf
@@ -57,7 +57,7 @@ resource "random_string" "id" {
 resource "aws_cloudwatch_log_group" "otel_agent" {
   count             = var.cloudwatch_log_group_name == null ? 1 : 0
   name              = "/ecs/${local.name}-${random_string.id.result}"
-  retention_in_days  = var.cloudwatch_log_retention_days
+  retention_in_days = var.cloudwatch_log_retention_days
   tags              = local.tags
 }
 

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -178,8 +178,8 @@ You can control health checks using:
 | s3_supervisor_config_key | Optional S3 object key for the Supervisor config | `string` | `null` | no |
 | initial_fallback_configs | Initial Supervisor fallback configuration URLs (`s3://` paths). Applied only to the embedded Supervisor config. Requires `s3_config_bucket` when non-empty. | `list(string)` | `[]` | no |
 | profiling_enabled | Enable a separate profiling collector daemon service | `bool` | `false` | no |
-| profiling_s3_config_bucket | S3 bucket for the profiling collector config. Required in collector mode; optional override in supervised mode. | `string` | `null` | no |
-| profiling_s3_config_key | S3 object key for the profiling collector config. Required in collector mode; optional override in supervised mode. | `string` | `null` | no |
+| profiling_s3_config_bucket | S3 bucket for the profiling collector config. Required in collector mode; optional override in supervised mode. Must be set with `profiling_s3_config_key`. | `string` | `null` | no |
+| profiling_s3_config_key | S3 object key for the profiling collector config. Required in collector mode; optional override in supervised mode. Must be set with `profiling_s3_config_bucket`. | `string` | `null` | no |
 | profiling_initial_fallback_configs | Initial Supervisor fallback URLs for the profiling agent. Requires `s3_config_bucket` when non-empty. | `list(string)` | `[]` | no |
 | profiling_memory | Profiling task memory (MiB) | `number` | `512` | no |
 | config_source | Reserved for UI compatibility. Keep set to `s3`. | `string` | `"s3"` | no |
@@ -210,6 +210,7 @@ You can control health checks using:
 | `task_execution_role_arn must be null in service-only mode` | You set `task_definition_arn` but left `task_execution_role_arn` non-null. | Set `task_execution_role_arn = null` and `task_role_arn = null` when using `task_definition_arn`. |
 | `task_role_arn must be null in service-only mode` | Same as above for task role. | Same fix. |
 | `profiling_enabled cannot be used with task_definition_arn` | You enabled profiling in service-only mode. | Disable profiling or omit `task_definition_arn` so the module can create the profiling task. |
+| `profiling_s3_config_bucket and profiling_s3_config_key must both be set or both be null` | You set only one of the profiling S3 path inputs. | Set both values, or leave both unset. |
 
 ## Outputs
 

--- a/modules/ecs-ec2/README.md
+++ b/modules/ecs-ec2/README.md
@@ -16,6 +16,8 @@ In `supervised` mode, the module uses the supervised image, embeds a NOP Collect
 
 `initial_fallback_configs` is a list of full `s3://` object URLs injected into the embedded Supervisor config as `agent.initial_fallback_configs`. The default is an empty list (no startup fallback). This applies only to the embedded Supervisor configuration; an S3-provided Supervisor configuration is used as-is. When the list is non-empty, `s3_config_bucket` is required and every fallback URL must reference that bucket so the auto-created task role can read the objects. When `task_role_arn` is provided, that custom role must grant `s3:GetObject` access to the fallback objects.
 
+Set `profiling_enabled = true` to deploy a second daemon service for continuous profiling. The profiling agent follows `supervisor_enabled`. In collector mode, `profiling_s3_config_bucket` and `profiling_s3_config_key` are required. In supervised mode, those paths are optional overrides for the embedded NOP collector config. The profiling Supervisor config is always embedded and cannot be overridden from S3. Use `profiling_initial_fallback_configs` for profiling-specific fallback URLs. Supervised CDOT `v0.11.0` or later is required when using initial fallback configuration with profiling enabled. Profiling is not supported with `task_definition_arn`.
+
 The module passes these environment variables to the collector:
 - `CORALOGIX_DOMAIN` – region-specific domain (from coralogix_region)
 - `CORALOGIX_PRIVATE_KEY` – your API key
@@ -66,6 +68,47 @@ module "ecs-ec2" {
   s3_config_bucket = "my-otel-config-bucket"
   initial_fallback_configs = [
     "s3://my-otel-config-bucket.s3.eu-north-1.amazonaws.com/<ACCOUNT_ID>/<GROUP_NAME>/<COLLECTOR_VERSION>/<REMOTE_CONFIG_NAME>/config.yaml",
+  ]
+}
+```
+
+For profiling in collector mode:
+
+```terraform
+module "ecs-ec2" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name  = "my-cluster"
+  image_version     = "v0.5.10"
+  coralogix_region  = "EU1"
+  api_key           = "your-coralogix-api-key"
+  s3_config_bucket  = "my-otel-config-bucket"
+  s3_config_key     = "configs/otel-config.yaml"
+
+  profiling_enabled          = true
+  profiling_s3_config_bucket = "my-otel-config-bucket"
+  profiling_s3_config_key    = "configs/profiling-config.yaml"
+}
+```
+
+For profiling in Supervisor mode:
+
+```terraform
+module "ecs-ec2" {
+  source = "coralogix/aws/coralogix//modules/ecs-ec2"
+
+  ecs_cluster_name   = "my-cluster"
+  supervisor_enabled = true
+  coralogix_region   = "EU1"
+  api_key            = "your-coralogix-api-key"
+  profiling_enabled  = true
+
+  s3_config_bucket = "my-otel-config-bucket"
+  initial_fallback_configs = [
+    "s3://my-otel-config-bucket.s3.eu-north-1.amazonaws.com/<ACCOUNT_ID>/<GROUP_NAME>/<COLLECTOR_VERSION>/main/config.yaml",
+  ]
+  profiling_initial_fallback_configs = [
+    "s3://my-otel-config-bucket.s3.eu-north-1.amazonaws.com/<ACCOUNT_ID>/<GROUP_NAME>/<COLLECTOR_VERSION>/profiling/config.yaml",
   ]
 }
 ```
@@ -127,13 +170,18 @@ You can control health checks using:
 | supervisor_enabled | Run the Collector through the Supervisor | `bool` | `false` | no |
 | image_version | Standard Coralogix Otel Collector image version/tag used in collector mode | `string` | `null` | yes* |
 | supervised_image_repository | Supervised Coralogix Otel Collector image repository | `string` | `"cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot"` | no |
-| supervised_image_version | Supervised Coralogix Otel Collector image version/tag | `string` | `"v0.10.0"` | no |
+| supervised_image_version | Supervised Coralogix Otel Collector image version/tag. Use `v0.11.0` or later with profiling fallbacks. | `string` | `"v0.11.0"` | no |
 | coralogix_region | Coralogix region: EU1, EU2, AP1, AP2, AP3, US1, US2, custom | `string` | `null` | yes* |
 | api_key | Send-Your-Data API key | `string` | `null` | yes** |
-| s3_config_bucket | S3 bucket containing collector and optional Supervisor configs. Also required when `initial_fallback_configs` is set. | `string` | `null` | yes* |
+| s3_config_bucket | S3 bucket containing collector and optional Supervisor configs. Also required when `initial_fallback_configs` or `profiling_initial_fallback_configs` is set. | `string` | `null` | yes* |
 | s3_config_key | S3 object key for the collector config | `string` | `null` | yes* |
 | s3_supervisor_config_key | Optional S3 object key for the Supervisor config | `string` | `null` | no |
 | initial_fallback_configs | Initial Supervisor fallback configuration URLs (`s3://` paths). Applied only to the embedded Supervisor config. Requires `s3_config_bucket` when non-empty. | `list(string)` | `[]` | no |
+| profiling_enabled | Enable a separate profiling collector daemon service | `bool` | `false` | no |
+| profiling_s3_config_bucket | S3 bucket for the profiling collector config. Required in collector mode; optional override in supervised mode. | `string` | `null` | no |
+| profiling_s3_config_key | S3 object key for the profiling collector config. Required in collector mode; optional override in supervised mode. | `string` | `null` | no |
+| profiling_initial_fallback_configs | Initial Supervisor fallback URLs for the profiling agent. Requires `s3_config_bucket` when non-empty. | `list(string)` | `[]` | no |
+| profiling_memory | Profiling task memory (MiB) | `number` | `512` | no |
 | config_source | Reserved for UI compatibility. Keep set to `s3`. | `string` | `"s3"` | no |
 | image | OTEL Collector image | `string` | `"coralogixrepo/coralogix-otel-collector"` | no |
 | memory | Task memory (MiB) | `number` | `256` | no |
@@ -161,6 +209,7 @@ You can control health checks using:
 |-------|-------|-----|
 | `task_execution_role_arn must be null in service-only mode` | You set `task_definition_arn` but left `task_execution_role_arn` non-null. | Set `task_execution_role_arn = null` and `task_role_arn = null` when using `task_definition_arn`. |
 | `task_role_arn must be null in service-only mode` | Same as above for task role. | Same fix. |
+| `profiling_enabled cannot be used with task_definition_arn` | You enabled profiling in service-only mode. | Disable profiling or omit `task_definition_arn` so the module can create the profiling task. |
 
 ## Outputs
 
@@ -168,3 +217,5 @@ You can control health checks using:
 |------|-------------|
 | coralogix_otel_agent_service_id | ID of the ECS Service |
 | coralogix_otel_agent_task_definition_arn | ARN of the ECS Task Definition |
+| coralogix_otel_profiling_agent_service_id | ID of the profiling ECS Service. Null when profiling is disabled. |
+| coralogix_otel_profiling_agent_task_definition_arn | ARN of the profiling ECS Task Definition. Null when profiling is disabled. |

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -44,8 +44,8 @@ locals {
   task_role_s3_object_resources = length(local.s3_object_resources) > 0 ? local.s3_object_resources : ["arn:aws:s3:::${local.s3_config_bucket}/*"]
   task_role_s3_bucket_resources = length(local.s3_bucket_resources) > 0 ? local.s3_bucket_resources : ["arn:aws:s3:::${local.s3_config_bucket}"]
   profiling_name                = "coralogix-otel-profiling-agent"
-  execution_role_arn = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
-  task_role_arn      = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
+  execution_role_arn            = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
+  task_role_arn                 = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 
   collector_config = <<-YAML
     receivers:

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -13,14 +13,36 @@ locals {
   coralogix_region_domain_map = module.locals_variables.coralogix_domains
   coralogix_domain            = var.task_definition_arn == null ? coalesce(var.custom_domain, local.coralogix_region_domain_map[var.coralogix_region]) : null
 
-  use_supervised_image     = var.supervisor_enabled
-  s3_config_bucket         = var.s3_config_bucket == null ? "" : var.s3_config_bucket
-  s3_config_key            = var.s3_config_key == null ? "" : var.s3_config_key
-  s3_supervisor_config_key = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
+  use_supervised_image       = var.supervisor_enabled
+  s3_config_bucket           = var.s3_config_bucket == null ? "" : var.s3_config_bucket
+  s3_config_key              = var.s3_config_key == null ? "" : var.s3_config_key
+  s3_supervisor_config_key   = var.s3_supervisor_config_key == null ? "" : var.s3_supervisor_config_key
+  profiling_s3_config_bucket = var.profiling_s3_config_bucket == null ? "" : var.profiling_s3_config_bucket
+  profiling_s3_config_key    = var.profiling_s3_config_key == null ? "" : var.profiling_s3_config_key
   # JSON array is valid YAML and correctly escapes commas/special chars in URLs.
-  initial_fallback_configs = jsonencode(var.initial_fallback_configs)
-  execution_role_arn       = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
-  task_role_arn            = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
+  initial_fallback_configs           = jsonencode(var.initial_fallback_configs)
+  profiling_initial_fallback_configs = jsonencode(var.profiling_initial_fallback_configs)
+  use_s3_collector_config            = trimspace(local.s3_config_bucket) != "" && trimspace(local.s3_config_key) != ""
+  use_s3_supervisor_config           = local.use_supervised_image && trimspace(local.s3_config_bucket) != "" && trimspace(local.s3_supervisor_config_key) != ""
+  use_s3_profiling_config            = var.profiling_enabled && trimspace(local.profiling_s3_config_bucket) != "" && trimspace(local.profiling_s3_config_key) != ""
+  use_main_s3_bucket = (
+    local.use_s3_collector_config ||
+    local.use_s3_supervisor_config ||
+    length(var.initial_fallback_configs) > 0 ||
+    length(var.profiling_initial_fallback_configs) > 0
+  )
+  s3_object_resources = distinct(compact([
+    local.use_main_s3_bucket ? "arn:aws:s3:::${local.s3_config_bucket}/*" : null,
+    local.use_s3_profiling_config ? "arn:aws:s3:::${local.profiling_s3_config_bucket}/*" : null,
+  ]))
+  s3_bucket_resources = distinct(compact([
+    local.use_main_s3_bucket ? "arn:aws:s3:::${local.s3_config_bucket}" : null,
+    local.use_s3_profiling_config ? "arn:aws:s3:::${local.profiling_s3_config_bucket}" : null,
+  ]))
+  use_any_s3_config  = length(local.s3_object_resources) > 0
+  profiling_name     = "coralogix-otel-profiling-agent"
+  execution_role_arn = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
+  task_role_arn      = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 
   collector_config = <<-YAML
     receivers:
@@ -71,9 +93,43 @@ locals {
     agent:
       executable: /cdot
       passthrough_logs: true
+      args: ["--feature-gates=+service.profilesSupport"]
       config_files:
         - /otel-config/collector-config.yaml
       initial_fallback_configs: ${local.initial_fallback_configs}
+
+    storage:
+      directory: /etc/otelcol-contrib/supervisor-data/
+
+    telemetry:
+      logs:
+        level: info
+  YAML
+
+  profiling_supervisor_config = <<-YAML
+    server:
+      endpoint: "https://ingress.$${env:CORALOGIX_DOMAIN}/opamp/v1"
+      headers:
+        Authorization: "Bearer $${env:CORALOGIX_PRIVATE_KEY}"
+      tls:
+        insecure_skip_verify: false
+
+    capabilities:
+      reports_effective_config: true
+      reports_own_metrics: true
+      reports_own_logs: true
+      reports_own_traces: true
+      reports_health: true
+      accepts_remote_config: true
+      reports_remote_config: true
+
+    agent:
+      executable: /cdot
+      passthrough_logs: true
+      args: ["--feature-gates=+service.profilesSupport"]
+      config_files:
+        - /otel-config/collector-config.yaml
+      initial_fallback_configs: ${local.profiling_initial_fallback_configs}
 
     storage:
       directory: /etc/otelcol-contrib/supervisor-data/
@@ -102,6 +158,23 @@ locals {
       fi
     fi
   SH
+
+  profiling_config_loader_command = <<-SH
+    set -e
+    if [ -n "$PROFILING_S3_CONFIG_BUCKET" ] && [ -n "$PROFILING_S3_CONFIG_KEY" ]; then
+      aws s3 cp "s3://$PROFILING_S3_CONFIG_BUCKET/$PROFILING_S3_CONFIG_KEY" /otel-config/collector-config.yaml
+    elif [ "$SUPERVISOR_ENABLED" = "true" ]; then
+      printf '%s\n' "$COLLECTOR_CONFIG" > /otel-config/collector-config.yaml
+    else
+      echo "profiling_s3_config_bucket and profiling_s3_config_key are required in collector mode" >&2
+      exit 1
+    fi
+    if [ "$SUPERVISOR_ENABLED" = "true" ]; then
+      printf '%s\n' "$SUPERVISOR_CONFIG" > /otel-config/supervisor.yaml
+    fi
+  SH
+
+  profiling_agent_command = local.use_supervised_image ? "mkdir -p /sys/kernel/debug /sys/kernel/tracing && mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true; mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null || true; exec /opampsupervisor -config /otel-config/supervisor.yaml" : "mkdir -p /sys/kernel/debug /sys/kernel/tracing && mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null || true; mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null || true; exec /cdot --feature-gates=+service.profilesSupport --config /otel-config/collector-config.yaml"
 }
 
 module "locals_variables" {
@@ -189,9 +262,9 @@ resource "aws_iam_role_policy" "otel_task_execution_role_secrets" {
   })
 }
 
-# IAM Role for task runtime S3 access (created when module creates task definition and no custom task role provided)
+# IAM Role for task runtime S3 access (created when module creates task definition, no custom task role, and S3 access is needed)
 resource "aws_iam_role" "otel_task_role_s3" {
-  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
   name  = "${local.name}-${random_string.id.result}-task-role-s3"
 
   assume_role_policy = jsonencode({
@@ -211,7 +284,7 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
   name  = "S3ReadAccess"
   role  = aws_iam_role.otel_task_role_s3[0].id
 
@@ -224,14 +297,14 @@ resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
           "s3:GetObject",
           "s3:GetObjectVersion"
         ]
-        Resource = "arn:aws:s3:::${local.s3_config_bucket}/*"
+        Resource = local.s3_object_resources
       },
       {
         Effect = "Allow"
         Action = [
           "s3:ListBucket"
         ]
-        Resource = "arn:aws:s3:::${local.s3_config_bucket}"
+        Resource = local.s3_bucket_resources
       }
     ]
   })
@@ -417,6 +490,187 @@ resource "aws_ecs_service" "coralogix_otel_agent" {
   tags = merge(
     {
       Name = "${local.name}-${random_string.id.result}"
+    },
+    var.tags
+  )
+}
+
+resource "aws_ecs_task_definition" "coralogix_otel_profiling_agent" {
+  count                    = var.task_definition_arn == null && var.profiling_enabled ? 1 : 0
+  family                   = "${local.profiling_name}-${random_string.id.result}"
+  cpu                      = max(var.profiling_memory, 256)
+  memory                   = var.profiling_memory
+  requires_compatibilities = ["EC2"]
+  network_mode             = "bridge"
+  execution_role_arn       = local.execution_role_arn
+  task_role_arn            = local.task_role_arn
+
+  volume {
+    name = "otel-config"
+  }
+  volume {
+    name      = "hostfs"
+    host_path = "/var/lib/docker/"
+  }
+  volume {
+    name      = "docker-socket"
+    host_path = "/var/run/docker.sock"
+  }
+  volume {
+    name      = "tracefs"
+    host_path = "/sys/kernel/tracing"
+  }
+  volume {
+    name      = "debugfs"
+    host_path = "/sys/kernel/debug"
+  }
+
+  tags = merge(
+    {
+      Name = "${local.profiling_name}-${random_string.id.result}"
+    },
+    var.tags
+  )
+
+  container_definitions = jsonencode([
+    {
+      name              = "profiling-config-loader"
+      image             = "public.ecr.aws/aws-cli/aws-cli:2.28.17"
+      essential         = false
+      memoryReservation = 32
+      entryPoint        = ["sh", "-c"]
+      command           = [local.profiling_config_loader_command]
+      environment = concat(
+        [
+          {
+            name  = "SUPERVISOR_ENABLED"
+            value = tostring(var.supervisor_enabled)
+          },
+          {
+            name  = "PROFILING_S3_CONFIG_BUCKET"
+            value = local.profiling_s3_config_bucket
+          },
+          {
+            name  = "PROFILING_S3_CONFIG_KEY"
+            value = local.profiling_s3_config_key
+          }
+        ],
+        local.use_supervised_image ? [
+          {
+            name  = "COLLECTOR_CONFIG"
+            value = local.collector_config
+          },
+          {
+            name  = "SUPERVISOR_CONFIG"
+            value = local.profiling_supervisor_config
+          }
+        ] : []
+      )
+      mountPoints = [
+        {
+          sourceVolume  = "otel-config"
+          containerPath = "/otel-config"
+        }
+      ]
+    },
+    {
+      name       = local.profiling_name
+      image      = local.use_supervised_image ? "${var.supervised_image_repository}:${var.supervised_image_version}" : "${var.image}:${coalesce(var.image_version, "v0.5.10")}"
+      essential  = true
+      privileged = true
+      user       = "0"
+      entryPoint = ["sh", "-c"]
+      command    = [local.profiling_agent_command]
+      memory     = var.profiling_memory
+      dependsOn = [
+        {
+          containerName = "profiling-config-loader"
+          condition     = "SUCCESS"
+        }
+      ]
+      mountPoints = [
+        {
+          sourceVolume  = "otel-config"
+          containerPath = "/otel-config"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "hostfs"
+          containerPath = "/hostfs/var/lib/docker"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "docker-socket"
+          containerPath = "/var/run/docker.sock"
+        },
+        {
+          sourceVolume  = "tracefs"
+          containerPath = "/sys/kernel/tracing"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "debugfs"
+          containerPath = "/sys/kernel/debug"
+          readOnly      = true
+        }
+      ]
+      environment = concat(
+        [
+          {
+            name  = "CORALOGIX_DOMAIN"
+            value = local.coralogix_domain
+          }
+        ],
+        var.use_api_key_secret != true ? [
+          {
+            name  = "CORALOGIX_PRIVATE_KEY"
+            value = var.api_key
+          }
+        ] : []
+      )
+      secrets = var.use_api_key_secret == true ? [
+        {
+          name      = "CORALOGIX_PRIVATE_KEY"
+          valueFrom = var.api_key_secret_arn
+        }
+      ] : []
+      healthCheck = var.health_check_enabled ? {
+        command     = ["CMD", "/healthcheck"]
+        startPeriod = var.health_check_start_period
+        interval    = var.health_check_interval
+        timeout     = var.health_check_timeout
+        retries     = var.health_check_retries
+      } : null
+      logConfiguration = {
+        logDriver = "json-file"
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "coralogix_otel_profiling_agent" {
+  count                              = var.task_definition_arn == null && var.profiling_enabled ? 1 : 0
+  name                               = "${local.profiling_name}-${random_string.id.result}"
+  cluster                            = var.ecs_cluster_name
+  launch_type                        = "EC2"
+  task_definition                    = aws_ecs_task_definition.coralogix_otel_profiling_agent[0].arn
+  scheduling_strategy                = "DAEMON"
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  deployment_controller {
+    type = "ECS"
+  }
+  service_connect_configuration {
+    enabled = false
+  }
+  enable_ecs_managed_tags = true
+  tags = merge(
+    {
+      Name = "${local.profiling_name}-${random_string.id.result}"
     },
     var.tags
   )

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -505,6 +505,7 @@ resource "aws_ecs_task_definition" "coralogix_otel_profiling_agent" {
   memory                   = var.profiling_memory
   requires_compatibilities = ["EC2"]
   network_mode             = "bridge"
+  pid_mode                 = "host"
   execution_role_arn       = local.execution_role_arn
   task_role_arn            = local.task_role_arn
 
@@ -518,6 +519,18 @@ resource "aws_ecs_task_definition" "coralogix_otel_profiling_agent" {
   volume {
     name      = "docker-socket"
     host_path = "/var/run/docker.sock"
+  }
+  volume {
+    name      = "procfs"
+    host_path = "/proc"
+  }
+  volume {
+    name      = "sysfs"
+    host_path = "/sys"
+  }
+  volume {
+    name      = "cgroupfs"
+    host_path = "/sys/fs/cgroup"
   }
   volume {
     name      = "tracefs"
@@ -605,6 +618,21 @@ resource "aws_ecs_task_definition" "coralogix_otel_profiling_agent" {
         {
           sourceVolume  = "docker-socket"
           containerPath = "/var/run/docker.sock"
+        },
+        {
+          sourceVolume  = "procfs"
+          containerPath = "/hostfs/proc"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "sysfs"
+          containerPath = "/hostfs/sys"
+          readOnly      = true
+        },
+        {
+          sourceVolume  = "cgroupfs"
+          containerPath = "/hostfs/sys/fs/cgroup"
+          readOnly      = true
         },
         {
           sourceVolume  = "tracefs"

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -39,8 +39,11 @@ locals {
     local.use_main_s3_bucket ? "arn:aws:s3:::${local.s3_config_bucket}" : null,
     local.use_s3_profiling_config ? "arn:aws:s3:::${local.profiling_s3_config_bucket}" : null,
   ]))
-  use_any_s3_config  = length(local.s3_object_resources) > 0
-  profiling_name     = "coralogix-otel-profiling-agent"
+  # Keep previous empty-bucket ARNs when no S3 paths are configured so existing
+  # supervised-without-S3 installs do not destroy the auto-created task role/policy.
+  task_role_s3_object_resources = length(local.s3_object_resources) > 0 ? local.s3_object_resources : ["arn:aws:s3:::${local.s3_config_bucket}/*"]
+  task_role_s3_bucket_resources = length(local.s3_bucket_resources) > 0 ? local.s3_bucket_resources : ["arn:aws:s3:::${local.s3_config_bucket}"]
+  profiling_name                = "coralogix-otel-profiling-agent"
   execution_role_arn = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
   task_role_arn      = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 
@@ -262,9 +265,9 @@ resource "aws_iam_role_policy" "otel_task_execution_role_secrets" {
   })
 }
 
-# IAM Role for task runtime S3 access (created when module creates task definition, no custom task role, and S3 access is needed)
+# IAM Role for task runtime S3 access (created when module creates task definition and no custom task role)
 resource "aws_iam_role" "otel_task_role_s3" {
-  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
   name  = "${local.name}-${random_string.id.result}-task-role-s3"
 
   assume_role_policy = jsonencode({
@@ -284,7 +287,7 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null && local.use_any_s3_config ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
   name  = "S3ReadAccess"
   role  = aws_iam_role.otel_task_role_s3[0].id
 
@@ -297,14 +300,14 @@ resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
           "s3:GetObject",
           "s3:GetObjectVersion"
         ]
-        Resource = local.s3_object_resources
+        Resource = local.task_role_s3_object_resources
       },
       {
         Effect = "Allow"
         Action = [
           "s3:ListBucket"
         ]
-        Resource = local.s3_bucket_resources
+        Resource = local.task_role_s3_bucket_resources
       }
     ]
   })

--- a/modules/ecs-ec2/main.tf
+++ b/modules/ecs-ec2/main.tf
@@ -39,13 +39,9 @@ locals {
     local.use_main_s3_bucket ? "arn:aws:s3:::${local.s3_config_bucket}" : null,
     local.use_s3_profiling_config ? "arn:aws:s3:::${local.profiling_s3_config_bucket}" : null,
   ]))
-  # Keep previous empty-bucket ARNs when no S3 paths are configured so existing
-  # supervised-without-S3 installs do not destroy the auto-created task role/policy.
-  task_role_s3_object_resources = length(local.s3_object_resources) > 0 ? local.s3_object_resources : ["arn:aws:s3:::${local.s3_config_bucket}/*"]
-  task_role_s3_bucket_resources = length(local.s3_bucket_resources) > 0 ? local.s3_bucket_resources : ["arn:aws:s3:::${local.s3_config_bucket}"]
-  profiling_name                = "coralogix-otel-profiling-agent"
-  execution_role_arn            = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
-  task_role_arn                 = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
+  profiling_name     = "coralogix-otel-profiling-agent"
+  execution_role_arn = var.task_execution_role_arn != null ? var.task_execution_role_arn : try(aws_iam_role.otel_task_execution_role_s3[0].arn, null)
+  task_role_arn      = var.task_role_arn != null ? var.task_role_arn : try(aws_iam_role.otel_task_role_s3[0].arn, null)
 
   collector_config = <<-YAML
     receivers:
@@ -265,7 +261,7 @@ resource "aws_iam_role_policy" "otel_task_execution_role_secrets" {
   })
 }
 
-# IAM Role for task runtime S3 access (created when module creates task definition and no custom task role)
+# Keep the task role when S3 is unused to avoid replacing existing task definitions.
 resource "aws_iam_role" "otel_task_role_s3" {
   count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
   name  = "${local.name}-${random_string.id.result}-task-role-s3"
@@ -287,7 +283,7 @@ resource "aws_iam_role" "otel_task_role_s3" {
 }
 
 resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
-  count = var.task_definition_arn == null && var.task_role_arn == null ? 1 : 0
+  count = var.task_definition_arn == null && var.task_role_arn == null && length(local.s3_object_resources) > 0 ? 1 : 0
   name  = "S3ReadAccess"
   role  = aws_iam_role.otel_task_role_s3[0].id
 
@@ -300,14 +296,14 @@ resource "aws_iam_role_policy" "otel_task_role_s3_s3_policy" {
           "s3:GetObject",
           "s3:GetObjectVersion"
         ]
-        Resource = local.task_role_s3_object_resources
+        Resource = local.s3_object_resources
       },
       {
         Effect = "Allow"
         Action = [
           "s3:ListBucket"
         ]
-        Resource = local.task_role_s3_bucket_resources
+        Resource = local.s3_bucket_resources
       }
     ]
   })

--- a/modules/ecs-ec2/output.tf
+++ b/modules/ecs-ec2/output.tf
@@ -7,3 +7,13 @@ output "coralogix_otel_agent_service_id" {
   value       = aws_ecs_service.coralogix_otel_agent.id
   description = "ID of the ECS Service for the OTEL Agent Daemon"
 }
+
+output "coralogix_otel_profiling_agent_task_definition_arn" {
+  value       = try(aws_ecs_task_definition.coralogix_otel_profiling_agent[0].arn, null)
+  description = "ARN of the ECS Task Definition for the profiling agent daemon. Null when profiling is disabled."
+}
+
+output "coralogix_otel_profiling_agent_service_id" {
+  value       = try(aws_ecs_service.coralogix_otel_profiling_agent[0].id, null)
+  description = "ID of the ECS Service for the profiling agent daemon. Null when profiling is disabled."
+}

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -20,7 +20,7 @@ variable "supervisor_enabled" {
 }
 
 variable "s3_config_bucket" {
-  description = "S3 bucket containing collector and optional Supervisor configurations. Required in collector mode. In supervised mode, omit it to use embedded configs. Ignored in service-only mode."
+  description = "S3 bucket containing collector and optional Supervisor configurations. Required in collector mode and when initial_fallback_configs or profiling_initial_fallback_configs is set. In supervised mode, omit it to use embedded configs. Ignored in service-only mode."
   type        = string
   default     = null
 
@@ -99,9 +99,9 @@ variable "supervised_image_repository" {
 }
 
 variable "supervised_image_version" {
-  description = "The supervised CDOT image version used in supervised mode."
+  description = "The supervised CDOT image version used in supervised mode. Use v0.11.0 or later when profiling_enabled is true and initial fallback configurations are set."
   type        = string
-  default     = "v0.10.0"
+  default     = "v0.11.0"
 
   validation {
     condition     = trimspace(var.supervised_image_version) != ""
@@ -113,6 +113,68 @@ variable "memory" {
   description = "The amount of memory (in MiB) used by the task. Note that your cluster must have sufficient memory available to support the given value. Minimum __256__ MiB. CPU Units will be allocated directly proportional to Memory."
   type        = number
   default     = 256
+}
+
+variable "profiling_enabled" {
+  description = "Enable a separate profiling collector daemon service. Follows supervisor_enabled for collector vs supervised mode. Not supported in service-only mode."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = !var.profiling_enabled || var.task_definition_arn == null
+    error_message = "profiling_enabled cannot be used with task_definition_arn. Service-only mode manages only the main ECS service."
+  }
+}
+
+variable "profiling_s3_config_bucket" {
+  description = "S3 bucket containing the profiling collector configuration. Required when profiling is enabled in collector mode. Optional override in supervised mode."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.profiling_enabled || var.supervisor_enabled || try(trimspace(var.profiling_s3_config_bucket) != "", false)
+    error_message = "profiling_s3_config_bucket is required when profiling is enabled in collector mode."
+  }
+}
+
+variable "profiling_s3_config_key" {
+  description = "S3 object key for the profiling collector configuration. Required when profiling is enabled in collector mode. Optional override in supervised mode."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.profiling_enabled || var.supervisor_enabled || try(trimspace(var.profiling_s3_config_key) != "", false)
+    error_message = "profiling_s3_config_key is required when profiling is enabled in collector mode."
+  }
+}
+
+variable "profiling_initial_fallback_configs" {
+  description = "Initial Supervisor fallback configuration URLs for the profiling agent (full s3:// object paths). Applied only to the embedded profiling Supervisor config. Requires s3_config_bucket when non-empty. Ignored when profiling is disabled or in service-only mode."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.profiling_initial_fallback_configs) == 0 || var.task_definition_arn != null || (var.profiling_enabled && var.supervisor_enabled)
+    error_message = "profiling_initial_fallback_configs requires profiling_enabled = true and supervisor_enabled = true when the module creates the task definition."
+  }
+
+  validation {
+    condition     = length(var.profiling_initial_fallback_configs) == 0 || var.task_definition_arn != null || try(trimspace(var.s3_config_bucket) != "", false)
+    error_message = "s3_config_bucket is required when profiling_initial_fallback_configs is set."
+  }
+
+  validation {
+    condition = alltrue([
+      for url in var.profiling_initial_fallback_configs : can(regex("^s3://.+", trimspace(url)))
+    ])
+    error_message = "Each profiling_initial_fallback_configs entry must be a non-empty s3:// URL."
+  }
+}
+
+variable "profiling_memory" {
+  description = "The amount of memory (in MiB) used by the profiling task."
+  type        = number
+  default     = 512
 }
 
 variable "coralogix_region" {

--- a/modules/ecs-ec2/variables.tf
+++ b/modules/ecs-ec2/variables.tf
@@ -127,7 +127,7 @@ variable "profiling_enabled" {
 }
 
 variable "profiling_s3_config_bucket" {
-  description = "S3 bucket containing the profiling collector configuration. Required when profiling is enabled in collector mode. Optional override in supervised mode."
+  description = "S3 bucket containing the profiling collector configuration. Required when profiling is enabled in collector mode. Optional override in supervised mode. Must be set together with profiling_s3_config_key."
   type        = string
   default     = null
 
@@ -135,10 +135,18 @@ variable "profiling_s3_config_bucket" {
     condition     = !var.profiling_enabled || var.supervisor_enabled || try(trimspace(var.profiling_s3_config_bucket) != "", false)
     error_message = "profiling_s3_config_bucket is required when profiling is enabled in collector mode."
   }
+
+  validation {
+    condition = (
+      try(trimspace(var.profiling_s3_config_bucket) != "", false) ==
+      try(trimspace(var.profiling_s3_config_key) != "", false)
+    )
+    error_message = "profiling_s3_config_bucket and profiling_s3_config_key must both be set or both be null."
+  }
 }
 
 variable "profiling_s3_config_key" {
-  description = "S3 object key for the profiling collector configuration. Required when profiling is enabled in collector mode. Optional override in supervised mode."
+  description = "S3 object key for the profiling collector configuration. Required when profiling is enabled in collector mode. Optional override in supervised mode. Must be set together with profiling_s3_config_bucket."
   type        = string
   default     = null
 

--- a/tests/ecs-ec2/README.md
+++ b/tests/ecs-ec2/README.md
@@ -28,6 +28,7 @@ terraform init
 terraform plan
 terraform apply
 ./verify-supervised-mode.sh
+./verify-profiling-mode.sh
 ```
 
 Expected: ECS Service `coralogix-otel-agent-<UUID>` runs as a Daemon; logs/traces/metrics sent to Coralogix.
@@ -38,6 +39,8 @@ Expected: ECS Service `coralogix-otel-agent-<UUID>` runs as a Daemon; logs/trace
 |----------|----------|--------------|
 | Supervised + embedded configs | Default test variables | None |
 | Supervised + S3 overrides | Pass all three S3 variables | `resources/s3` |
+| Profiling collector mode | `profiling_enabled=true` plus profiling S3 vars | `resources/s3` with a profiling config object |
+| Profiling Supervisor mode | `profiling_enabled=true` with default supervised vars | None |
 | 1. S3 + inline API key | `terraform.tfvars` | `resources/s3` |
 | 2. S3 + Secrets Manager (module auto-creates execution role) | `vars/example-secrets-manager.tfvars.template` | `resources/s3`, `resources/parameter-store` |
 | 3. Service-only (existing task definition) | `vars/example-service-only.tfvars.template` | Existing task definition ARN. Run `./verify-service-only-mode.sh` to assert no task definition or IAM resources are planned. |

--- a/tests/ecs-ec2/ecs-ec2.tf
+++ b/tests/ecs-ec2/ecs-ec2.tf
@@ -33,6 +33,12 @@ module "ecs-ec2" {
   s3_supervisor_config_key = var.s3_supervisor_config_key
   initial_fallback_configs = var.initial_fallback_configs
 
+  profiling_enabled                  = var.profiling_enabled
+  profiling_s3_config_bucket         = var.profiling_s3_config_bucket
+  profiling_s3_config_key            = var.profiling_s3_config_key
+  profiling_initial_fallback_configs = var.profiling_initial_fallback_configs
+  profiling_memory                   = var.profiling_memory
+
   task_execution_role_arn = var.task_execution_role_arn
   task_role_arn           = var.task_role_arn
   task_definition_arn     = var.task_definition_arn

--- a/tests/ecs-ec2/resources/roles-for-bucket/main.tf
+++ b/tests/ecs-ec2/resources/roles-for-bucket/main.tf
@@ -38,8 +38,8 @@ resource "aws_iam_role" "execution_role" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
       Principal = { Service = "ecs-tasks.amazonaws.com" }
     }]
   })
@@ -70,8 +70,8 @@ resource "aws_iam_role" "task_role" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action = "sts:AssumeRole"
-      Effect = "Allow"
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
       Principal = { Service = "ecs-tasks.amazonaws.com" }
     }]
   })

--- a/tests/ecs-ec2/variables.tf
+++ b/tests/ecs-ec2/variables.tf
@@ -37,7 +37,7 @@ variable "supervised_image_repository" {
 variable "supervised_image_version" {
   description = "Version tag for the supervised CDOT image"
   type        = string
-  default     = "v0.10.0"
+  default     = "v0.11.0"
 }
 
 variable "coralogix_region" {
@@ -93,6 +93,36 @@ variable "initial_fallback_configs" {
   description = "Initial Supervisor fallback configuration URLs"
   type        = list(string)
   default     = []
+}
+
+variable "profiling_enabled" {
+  description = "Whether to enable the profiling daemon"
+  type        = bool
+  default     = false
+}
+
+variable "profiling_s3_config_bucket" {
+  description = "S3 bucket for the profiling collector configuration"
+  type        = string
+  default     = null
+}
+
+variable "profiling_s3_config_key" {
+  description = "S3 object key for the profiling collector configuration"
+  type        = string
+  default     = null
+}
+
+variable "profiling_initial_fallback_configs" {
+  description = "Initial Supervisor fallback configuration URLs for the profiling agent"
+  type        = list(string)
+  default     = []
+}
+
+variable "profiling_memory" {
+  description = "Memory in MiB for the profiling task"
+  type        = number
+  default     = 512
 }
 
 variable "task_definition_arn" {

--- a/tests/ecs-ec2/verify-profiling-mode.sh
+++ b/tests/ecs-ec2/verify-profiling-mode.sh
@@ -159,12 +159,16 @@ if ! jq -e '
 fi
 
 if ! jq -e '
-  [.resource_changes[]
-    | select(.address | contains("otel_task_role_s3"))
+  any(.resource_changes[];
+    .address == "module.ecs-ec2.aws_iam_role.otel_task_role_s3[0]"
+    and (.change.actions | index("create"))
+  )
+  and ([.resource_changes[]
+    | select(.address == "module.ecs-ec2.aws_iam_role_policy.otel_task_role_s3_s3_policy[0]")
     | select(.change.actions | index("create"))]
-  | length == 2
+    | length == 0)
 ' "$SUPERVISED_JSON" >/dev/null; then
-  fail "Profiling Supervisor mode without S3 does not create the expected task role and S3 policy."
+  fail "Profiling Supervisor mode without S3 must create the task role without an S3 policy."
 fi
 
 echo "[INFO] Verifying profiling Supervisor fallbacks and S3 override..."

--- a/tests/ecs-ec2/verify-profiling-mode.sh
+++ b/tests/ecs-ec2/verify-profiling-mode.sh
@@ -244,4 +244,19 @@ if ! grep -q "profiling_enabled cannot be used with task_definition_arn" "$TMP_D
   fail "Service-only profiling rejection did not report the expected validation error."
 fi
 
+echo "[INFO] Verifying partial profiling S3 path overrides are rejected..."
+if terraform plan \
+  -input=false \
+  -lock=false \
+  -var='supervisor_enabled=true' \
+  -var='profiling_enabled=true' \
+  -var='profiling_s3_config_bucket=profiling-bucket' \
+  -out="$TMP_DIR/partial-profiling-s3.tfplan" >/dev/null 2>"$TMP_DIR/partial-profiling-s3.err"; then
+  fail "Setting only profiling_s3_config_bucket should fail validation."
+fi
+
+if ! grep -q "profiling_s3_config_bucket and profiling_s3_config_key must both be set" "$TMP_DIR/partial-profiling-s3.err"; then
+  fail "Partial profiling S3 override rejection did not report the expected validation error."
+fi
+
 echo "[PASS] Profiling mode creates the expected daemon, Supervisor wiring, IAM scope, and validations."

--- a/tests/ecs-ec2/verify-profiling-mode.sh
+++ b/tests/ecs-ec2/verify-profiling-mode.sh
@@ -154,9 +154,9 @@ if ! jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
-  | length == 0
+  | length == 2
 ' "$SUPERVISED_JSON" >/dev/null; then
-  fail "Profiling Supervisor mode without S3 should not create a task role or S3 policy."
+  fail "Profiling Supervisor mode without S3 does not create the expected task role and S3 policy."
 fi
 
 echo "[INFO] Verifying profiling Supervisor fallbacks and S3 override..."

--- a/tests/ecs-ec2/verify-profiling-mode.sh
+++ b/tests/ecs-ec2/verify-profiling-mode.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Verifies profiling daemon task and service planning for collector and Supervisor modes.
+# Contract: profiling_enabled creates a bridge-network daemon with kernel mounts and
+# profilesSupport. Supervisor mode embeds a profiling-specific Supervisor config with
+# separate fallback URLs. Collector mode requires profiling S3 config paths.
+#
+# Usage: ./verify-profiling-mode.sh
+#
+# Requires: terraform, jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "[FAIL] $1" >&2
+  exit 1
+}
+
+PROFILE_TASK_ADDRESS='module.ecs-ec2.aws_ecs_task_definition.coralogix_otel_profiling_agent[0]'
+PROFILE_SERVICE_ADDRESS='module.ecs-ec2.aws_ecs_service.coralogix_otel_profiling_agent[0]'
+
+echo "[INFO] Verifying profiling collector mode..."
+COLLECTOR_PLAN="$TMP_DIR/profiling-collector.tfplan"
+COLLECTOR_JSON="$TMP_DIR/profiling-collector.json"
+
+terraform plan \
+  -input=false \
+  -lock=false \
+  -var='supervisor_enabled=false' \
+  -var='profiling_enabled=true' \
+  -var='image_version=v0.5.10' \
+  -var='s3_config_bucket=main-bucket' \
+  -var='s3_config_key=configs/collector.yaml' \
+  -var='profiling_s3_config_bucket=profiling-bucket' \
+  -var='profiling_s3_config_key=configs/profiling.yaml' \
+  -var='health_check_enabled=true' \
+  -out="$COLLECTOR_PLAN" >/dev/null
+terraform show -json "$COLLECTOR_PLAN" > "$COLLECTOR_JSON"
+
+if ! jq -e --arg task "$PROFILE_TASK_ADDRESS" --arg service "$PROFILE_SERVICE_ADDRESS" '
+  any(.resource_changes[]; .address == $task and (.change.actions | index("create")))
+  and any(.resource_changes[]; .address == $service and (.change.actions | index("create")))
+' "$COLLECTOR_JSON" >/dev/null; then
+  fail "Profiling collector mode does not create the profiling task definition and service."
+fi
+
+PROFILE_TASK=$(jq -c --arg address "$PROFILE_TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$COLLECTOR_JSON")
+PROFILE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$PROFILE_TASK")
+
+if ! jq -e '
+  (.values.network_mode == "bridge")
+  and any(.values.volume[]; .name == "tracefs" and .host_path == "/sys/kernel/tracing")
+  and any(.values.volume[]; .name == "debugfs" and .host_path == "/sys/kernel/debug")
+' <<< "$PROFILE_TASK" >/dev/null; then
+  fail "Profiling task definition is missing bridge networking or kernel volumes."
+fi
+
+if ! jq -e '
+  any(.[];
+    .name == "profiling-config-loader"
+    and any(.environment[]; .name == "PROFILING_S3_CONFIG_BUCKET" and .value == "profiling-bucket")
+    and any(.environment[]; .name == "PROFILING_S3_CONFIG_KEY" and .value == "configs/profiling.yaml")
+    and (.command[0] | contains("PROFILING_S3_CONFIG_BUCKET"))
+  )
+  and any(.[];
+    .name == "coralogix-otel-profiling-agent"
+    and .image == "coralogixrepo/coralogix-otel-collector:v0.5.10"
+    and .privileged == true
+    and .user == "0"
+    and .entryPoint == ["sh", "-c"]
+    and (.command[0] | contains("exec /cdot --feature-gates=+service.profilesSupport --config /otel-config/collector-config.yaml"))
+    and (.command[0] | contains("mount -t debugfs"))
+    and (.command[0] | contains("mount -t tracefs"))
+    and any(.mountPoints[]; .containerPath == "/sys/kernel/tracing" and .readOnly == true)
+    and any(.mountPoints[]; .containerPath == "/sys/kernel/debug" and .readOnly == true)
+    and .healthCheck.command == ["CMD", "/healthcheck"]
+    and any(.dependsOn[]; .containerName == "profiling-config-loader" and .condition == "SUCCESS")
+  )
+' <<< "$PROFILE_CONTAINERS" >/dev/null; then
+  fail "Profiling collector mode does not configure the expected loader, mounts, or feature gate."
+fi
+
+COLLECTOR_POLICY=$(jq -r '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == "module.ecs-ec2.aws_iam_role_policy.otel_task_role_s3_s3_policy[0]")
+  | .values.policy
+' "$COLLECTOR_JSON")
+
+if ! jq -e '
+  any(.Statement[];
+    (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
+    and (.Resource | sort) == (["arn:aws:s3:::main-bucket/*", "arn:aws:s3:::profiling-bucket/*"] | sort)
+  )
+  and any(.Statement[];
+    .Action == ["s3:ListBucket"]
+    and (.Resource | sort) == (["arn:aws:s3:::main-bucket", "arn:aws:s3:::profiling-bucket"] | sort)
+  )
+' <<< "$COLLECTOR_POLICY" >/dev/null; then
+  fail "Profiling collector mode does not grant S3 access to both main and profiling buckets."
+fi
+
+echo "[INFO] Verifying profiling Supervisor mode with embedded configs..."
+SUPERVISED_PLAN="$TMP_DIR/profiling-supervised.tfplan"
+SUPERVISED_JSON="$TMP_DIR/profiling-supervised.json"
+
+terraform plan \
+  -input=false \
+  -lock=false \
+  -var='profiling_enabled=true' \
+  -var='health_check_enabled=true' \
+  -out="$SUPERVISED_PLAN" >/dev/null
+terraform show -json "$SUPERVISED_PLAN" > "$SUPERVISED_JSON"
+
+SUPERVISED_TASK=$(jq -c --arg address "$PROFILE_TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$SUPERVISED_JSON")
+SUPERVISED_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$SUPERVISED_TASK")
+
+if ! jq -e '
+  any(.[];
+    .name == "profiling-config-loader"
+    and any(.environment[];
+      .name == "COLLECTOR_CONFIG"
+      and (.value | contains("receivers:\n  nop:"))
+    )
+    and any(.environment[];
+      .name == "SUPERVISOR_CONFIG"
+      and (.value | contains("opamp/v1"))
+      and (.value | contains("--feature-gates=+service.profilesSupport"))
+      and (.value | contains("initial_fallback_configs: []"))
+    )
+  )
+  and any(.[];
+    .name == "coralogix-otel-profiling-agent"
+    and .image == "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot:v0.11.0"
+    and (.command[0] | contains("exec /opampsupervisor -config /otel-config/supervisor.yaml"))
+    and (.command[0] | contains("mount -t debugfs"))
+    and .healthCheck.command == ["CMD", "/healthcheck"]
+  )
+' <<< "$SUPERVISED_CONTAINERS" >/dev/null; then
+  fail "Profiling Supervisor mode does not embed the expected NOP and Supervisor configs."
+fi
+
+if ! jq -e '
+  [.resource_changes[]
+    | select(.address | contains("otel_task_role_s3"))
+    | select(.change.actions | index("create"))]
+  | length == 0
+' "$SUPERVISED_JSON" >/dev/null; then
+  fail "Profiling Supervisor mode without S3 should not create a task role or S3 policy."
+fi
+
+echo "[INFO] Verifying profiling Supervisor fallbacks and S3 override..."
+FALLBACK_PLAN="$TMP_DIR/profiling-fallback.tfplan"
+FALLBACK_JSON="$TMP_DIR/profiling-fallback.json"
+MAIN_FALLBACK="s3://placeholder-bucket.s3.us-east-1.amazonaws.com/account/group/EMPTY_VERSION/main/config.yaml"
+PROFILE_FALLBACK="s3://placeholder-bucket.s3.us-east-1.amazonaws.com/account/group/EMPTY_VERSION/profiling/config.yaml"
+
+terraform plan \
+  -input=false \
+  -lock=false \
+  -var='profiling_enabled=true' \
+  -var='s3_config_bucket=placeholder-bucket' \
+  -var='profiling_s3_config_bucket=profiling-bucket' \
+  -var='profiling_s3_config_key=configs/profiling.yaml' \
+  -var="initial_fallback_configs=[\"$MAIN_FALLBACK\"]" \
+  -var="profiling_initial_fallback_configs=[\"$PROFILE_FALLBACK\"]" \
+  -out="$FALLBACK_PLAN" >/dev/null
+terraform show -json "$FALLBACK_PLAN" > "$FALLBACK_JSON"
+
+MAIN_TASK=$(jq -c '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == "module.ecs-ec2.aws_ecs_task_definition.coralogix_otel_agent[0]")
+' "$FALLBACK_JSON")
+MAIN_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$MAIN_TASK")
+FALLBACK_PROFILE_TASK=$(jq -c --arg address "$PROFILE_TASK_ADDRESS" '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == $address)
+' "$FALLBACK_JSON")
+FALLBACK_PROFILE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$FALLBACK_PROFILE_TASK")
+
+if ! jq -e --arg url "$MAIN_FALLBACK" '
+  any(.[];
+    .name == "config-loader"
+    and any(.environment[];
+      .name == "SUPERVISOR_CONFIG"
+      and (.value | contains($url))
+      and (.value | contains("--feature-gates=+service.profilesSupport"))
+    )
+  )
+' <<< "$MAIN_CONTAINERS" >/dev/null; then
+  fail "Main Supervisor config does not embed the main fallback URL."
+fi
+
+if ! jq -e --arg main_url "$MAIN_FALLBACK" --arg profile_url "$PROFILE_FALLBACK" '
+  any(.[];
+    .name == "profiling-config-loader"
+    and any(.environment[]; .name == "PROFILING_S3_CONFIG_BUCKET" and .value == "profiling-bucket")
+    and any(.environment[];
+      .name == "SUPERVISOR_CONFIG"
+      and (.value | contains($profile_url))
+      and ((.value | contains($main_url)) | not)
+    )
+  )
+' <<< "$FALLBACK_PROFILE_CONTAINERS" >/dev/null; then
+  fail "Profiling Supervisor config does not keep fallback URLs separate from the main agent."
+fi
+
+FALLBACK_POLICY=$(jq -r '
+  .planned_values.root_module.child_modules[].resources[]
+  | select(.address == "module.ecs-ec2.aws_iam_role_policy.otel_task_role_s3_s3_policy[0]")
+  | .values.policy
+' "$FALLBACK_JSON")
+
+if ! jq -e '
+  any(.Statement[];
+    (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
+    and (.Resource | sort) == (["arn:aws:s3:::placeholder-bucket/*", "arn:aws:s3:::profiling-bucket/*"] | sort)
+  )
+' <<< "$FALLBACK_POLICY" >/dev/null; then
+  fail "Profiling fallbacks do not grant S3 access to the main and profiling buckets."
+fi
+
+echo "[INFO] Verifying profiling_enabled is rejected in service-only mode..."
+if terraform plan \
+  -input=false \
+  -lock=false \
+  -var='task_definition_arn=arn:aws:ecs:us-east-1:123456789012:task-definition/coralogix-otel-agent-test:1' \
+  -var='profiling_enabled=true' \
+  -out="$TMP_DIR/service-only-profiling.tfplan" >/dev/null 2>"$TMP_DIR/service-only-profiling.err"; then
+  fail "profiling_enabled with task_definition_arn should fail validation."
+fi
+
+if ! grep -q "profiling_enabled cannot be used with task_definition_arn" "$TMP_DIR/service-only-profiling.err"; then
+  fail "Service-only profiling rejection did not report the expected validation error."
+fi
+
+echo "[PASS] Profiling mode creates the expected daemon, Supervisor wiring, IAM scope, and validations."

--- a/tests/ecs-ec2/verify-profiling-mode.sh
+++ b/tests/ecs-ec2/verify-profiling-mode.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Verifies profiling daemon task and service planning for collector and Supervisor modes.
-# Contract: profiling_enabled creates a bridge-network daemon with kernel mounts and
-# profilesSupport. Supervisor mode embeds a profiling-specific Supervisor config with
-# separate fallback URLs. Collector mode requires profiling S3 config paths.
+# Contract: profiling_enabled creates a bridge-network daemon with host PID visibility,
+# host process/kernel mounts, and profilesSupport. Supervisor mode embeds a
+# profiling-specific Supervisor config with separate fallback URLs. Collector mode
+# requires profiling S3 config paths.
 #
 # Usage: ./verify-profiling-mode.sh
 #
@@ -57,10 +58,14 @@ PROFILE_CONTAINERS=$(jq -r '.values.container_definitions' <<< "$PROFILE_TASK")
 
 if ! jq -e '
   (.values.network_mode == "bridge")
+  and (.values.pid_mode == "host")
+  and any(.values.volume[]; .name == "procfs" and .host_path == "/proc")
+  and any(.values.volume[]; .name == "sysfs" and .host_path == "/sys")
+  and any(.values.volume[]; .name == "cgroupfs" and .host_path == "/sys/fs/cgroup")
   and any(.values.volume[]; .name == "tracefs" and .host_path == "/sys/kernel/tracing")
   and any(.values.volume[]; .name == "debugfs" and .host_path == "/sys/kernel/debug")
 ' <<< "$PROFILE_TASK" >/dev/null; then
-  fail "Profiling task definition is missing bridge networking or kernel volumes."
+  fail "Profiling task definition is missing host PID visibility or host filesystem volumes."
 fi
 
 if ! jq -e '
@@ -79,6 +84,9 @@ if ! jq -e '
     and (.command[0] | contains("exec /cdot --feature-gates=+service.profilesSupport --config /otel-config/collector-config.yaml"))
     and (.command[0] | contains("mount -t debugfs"))
     and (.command[0] | contains("mount -t tracefs"))
+    and any(.mountPoints[]; .containerPath == "/hostfs/proc" and .readOnly == true)
+    and any(.mountPoints[]; .containerPath == "/hostfs/sys" and .readOnly == true)
+    and any(.mountPoints[]; .containerPath == "/hostfs/sys/fs/cgroup" and .readOnly == true)
     and any(.mountPoints[]; .containerPath == "/sys/kernel/tracing" and .readOnly == true)
     and any(.mountPoints[]; .containerPath == "/sys/kernel/debug" and .readOnly == true)
     and .healthCheck.command == ["CMD", "/healthcheck"]

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -55,12 +55,13 @@ if ! jq -e '
       and (.value | contains("opamp/v1"))
       and (.value | contains("- /otel-config/collector-config.yaml"))
       and (.value | contains("initial_fallback_configs: []"))
+      and (.value | contains("--feature-gates=+service.profilesSupport"))
     )
     and any(.mountPoints[]; .containerPath == "/otel-config")
   )
   and any(.[];
     .name == "coralogix-otel-agent"
-    and .image == "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot:v0.10.0"
+    and .image == "cgx.jfrog.io/coralogix-docker-images/coralogix-otel-supervised-cdot:v0.11.0"
     and .privileged == true
     and (has("entryPoint") | not)
     and .command == ["--config", "/otel-config/supervisor.yaml"]
@@ -79,9 +80,18 @@ if ! jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
-  | length == 2
+  | length == 0
 ' "$INLINE_JSON" >/dev/null; then
-  fail "Embedded Supervisor mode does not create the expected task role and S3 policy."
+  fail "Embedded Supervisor mode without S3 should not create a task role or S3 policy."
+fi
+
+if ! jq -e '
+  [.resource_changes[]
+    | select(.address | contains("coralogix_otel_profiling_agent"))
+    | select(.change.actions | index("create"))]
+  | length == 0
+' "$INLINE_JSON" >/dev/null; then
+  fail "Profiling resources should not be created when profiling_enabled is false."
 fi
 
 echo "[INFO] Verifying Supervisor mode with S3 configuration overrides..."
@@ -112,11 +122,11 @@ S3_POLICY=$(jq -r '
 if ! jq -e '
   any(.Statement[];
     (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
-    and .Resource == "arn:aws:s3:::placeholder-bucket/*"
+    and ((.Resource | if type == "array" then . else [.] end) | sort) == ["arn:aws:s3:::placeholder-bucket/*"]
   )
   and any(.Statement[];
-    .Action == ["s3:ListBucket"]
-    and .Resource == "arn:aws:s3:::placeholder-bucket"
+    (.Action | if type == "array" then . else [.] end) == ["s3:ListBucket"]
+    and ((.Resource | if type == "array" then . else [.] end) | sort) == ["arn:aws:s3:::placeholder-bucket"]
   )
 ' <<< "$S3_POLICY" >/dev/null; then
   fail "The task role policy does not grant the expected read access to the configured S3 bucket."
@@ -182,7 +192,7 @@ FALLBACK_POLICY=$(jq -r '
 if ! jq -e '
   any(.Statement[];
     (.Action | sort) == (["s3:GetObject", "s3:GetObjectVersion"] | sort)
-    and .Resource == "arn:aws:s3:::placeholder-bucket/*"
+    and ((.Resource | if type == "array" then . else [.] end) | sort) == ["arn:aws:s3:::placeholder-bucket/*"]
   )
 ' <<< "$FALLBACK_POLICY" >/dev/null; then
   fail "initial_fallback_configs does not grant the expected S3 read access via s3_config_bucket."

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -77,12 +77,16 @@ if ! jq -e '
 fi
 
 if ! jq -e '
-  [.resource_changes[]
-    | select(.address | contains("otel_task_role_s3"))
+  any(.resource_changes[];
+    .address == "module.ecs-ec2.aws_iam_role.otel_task_role_s3[0]"
+    and (.change.actions | index("create"))
+  )
+  and ([.resource_changes[]
+    | select(.address == "module.ecs-ec2.aws_iam_role_policy.otel_task_role_s3_s3_policy[0]")
     | select(.change.actions | index("create"))]
-  | length == 2
+    | length == 0)
 ' "$INLINE_JSON" >/dev/null; then
-  fail "Embedded Supervisor mode does not create the expected task role and S3 policy."
+  fail "Embedded Supervisor mode without S3 must create the task role without an S3 policy."
 fi
 
 if ! jq -e '

--- a/tests/ecs-ec2/verify-supervised-mode.sh
+++ b/tests/ecs-ec2/verify-supervised-mode.sh
@@ -80,9 +80,9 @@ if ! jq -e '
   [.resource_changes[]
     | select(.address | contains("otel_task_role_s3"))
     | select(.change.actions | index("create"))]
-  | length == 0
+  | length == 2
 ' "$INLINE_JSON" >/dev/null; then
-  fail "Embedded Supervisor mode without S3 should not create a task role or S3 policy."
+  fail "Embedded Supervisor mode does not create the expected task role and S3 policy."
 fi
 
 if ! jq -e '


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> 

Fixes CX-50375.

This PR implements support for the profiling receiver in the ecs-ec2 integration. It also works with the Supervisor and supports initial fallback configuration in this case.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Ran smoke tests on a real ECS EC2 cluster.

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)