### PR TITLE
feat(firehose): support Secrets Manager for Coralogix API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### **firehose-logs**, **firehose-metrics**
 ### 💡 Enhancements 💡
 - Added optional Secrets Manager support for the Coralogix API key via `api_key_secret_arn` (and optional `api_key_secret_kms_key_arn` for CMK-encrypted secrets). When set, Firehose uses `secrets_manager_configuration` to fetch `{"api_key": "..."}` at runtime instead of freezing a literal `access_key` at apply time. `api_key` remains supported and is required unless a secret ARN is provided.
+- Raised `firehose-logs` Terraform `required_version` to `>= 1.9.0` (matching `firehose-metrics`) so the cross-variable `api_key` / `api_key_secret_arn` validation is supported.
 
 ## v4.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.10.0
+
+#### **firehose-logs**, **firehose-metrics**
+### 💡 Enhancements 💡
+- Added optional Secrets Manager support for the Coralogix API key via `api_key_secret_arn` (and optional `api_key_secret_kms_key_arn` for CMK-encrypted secrets). When set, Firehose uses `secrets_manager_configuration` to fetch `{"api_key": "..."}` at runtime instead of freezing a literal `access_key` at apply time. `api_key` remains supported and is required unless a secret ARN is provided.
+
 ## v4.9.0
 
 #### **ecs-ec2**

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -90,7 +90,7 @@ It is possible to pass a custom Coralogix domain by using the `custom_domain` va
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.17.1 |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 
 ## Providers
 

--- a/modules/firehose-logs/README.md
+++ b/modules/firehose-logs/README.md
@@ -19,6 +19,21 @@ module "cloudwatch_firehose_logs_coralogix" {
 }
 ```
 
+### Secrets Manager API key
+
+Optionally pass `api_key_secret_arn` instead of `api_key` so Firehose fetches the key at runtime via `SecretsManagerConfiguration`. The secret value must be JSON: `{"api_key": "..."}`. Rotating the secret then takes effect without a Terraform apply. If the secret is encrypted with a customer managed KMS key, also set `api_key_secret_kms_key_arn`. When the module creates the Firehose IAM role, it grants `secretsmanager:GetSecretValue` (and `kms:Decrypt` when a CMK ARN is set). If you pass `existing_firehose_iam`, that role must already allow those actions.
+
+```terraform
+module "cloudwatch_firehose_logs_coralogix" {
+  source              = "coralogix/aws/coralogix//modules/firehose-logs"
+  firehose_stream     = var.coralogix_firehose_stream_name
+  api_key_secret_arn  = var.api_key_secret_arn
+  coralogix_region    = var.coralogix_region
+  integration_type_logs = "Default"
+  source_type_logs      = "DirectPut"
+}
+```
+
 ### Dynamic Values Table for Logs
 
 For `application_name` and/or `subsystem_name` to be set dynamically in relation to their `integrationType`'s resource fields (e.g. CloudWatch_JSON's loggroup name, EksFargate's k8s namespace). The source's `var` has to be mapped as a string literal to the `integrationType`'s as a DynamicFromField with pre-defined values:

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.9.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/firehose-logs/main.tf
+++ b/modules/firehose-logs/main.tf
@@ -35,6 +35,9 @@ locals {
   new_firehose_iam_name     = var.firehose_iam_custom_name != null ? var.firehose_iam_custom_name : "${var.firehose_stream}-firehose-logs-iam"
 
   arn_prefix = var.govcloud_deployment ? "arn:aws-us-gov" : "arn:aws"
+
+  use_secrets_manager = var.api_key_secret_arn != null && var.api_key_secret_arn != ""
+  use_api_key_kms     = var.api_key_secret_kms_key_arn != null && var.api_key_secret_kms_key_arn != ""
 }
 
 data "aws_caller_identity" "current_identity" {}
@@ -184,6 +187,32 @@ data "aws_iam_policy_document" "new_firehose_policy" {
       aws_cloudwatch_log_group.firehose_loggroup.arn,
     ]
   }
+
+  dynamic "statement" {
+    for_each = local.use_secrets_manager ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "secretsmanager:GetSecretValue",
+      ]
+      resources = [
+        var.api_key_secret_arn,
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = local.use_secrets_manager && local.use_api_key_kms ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+      ]
+      resources = [
+        var.api_key_secret_kms_key_arn,
+      ]
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "new_firehose_policy" {
@@ -228,12 +257,21 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_logs" {
   http_endpoint_configuration {
     url                = local.endpoint_url
     name               = "Coralogix"
-    access_key         = var.api_key
+    access_key         = local.use_secrets_manager ? null : var.api_key
     buffering_size     = 1
     buffering_interval = 60
     s3_backup_mode     = "FailedDataOnly"
     role_arn           = local.firehose_iam_role_arn
     retry_duration     = 300
+
+    dynamic "secrets_manager_configuration" {
+      for_each = local.use_secrets_manager ? [1] : []
+      content {
+        enabled    = true
+        secret_arn = var.api_key_secret_arn
+        role_arn   = local.firehose_iam_role_arn
+      }
+    }
 
     s3_configuration {
       role_arn           = local.firehose_iam_role_arn

--- a/modules/firehose-logs/variables.tf
+++ b/modules/firehose-logs/variables.tf
@@ -8,9 +8,37 @@ variable "coralogix_region" {
 }
 
 variable "api_key" {
-  description = "Coralogix account api key"
+  description = "Coralogix account API key. Ignored when api_key_secret_arn is set. Required unless api_key_secret_arn is provided."
   type        = string
   sensitive   = true
+  default     = null
+
+  validation {
+    condition     = (var.api_key != null && var.api_key != "") || (var.api_key_secret_arn != null && var.api_key_secret_arn != "")
+    error_message = "You must provide either api_key or api_key_secret_arn."
+  }
+}
+
+variable "api_key_secret_arn" {
+  description = <<-EOT
+    ARN of a Secrets Manager secret holding the Coralogix API key as JSON, {"api_key": "..."}.
+    When set, Firehose reads the key at runtime and api_key is ignored, so rotating the secret
+    takes effect without a Terraform apply. This must be a separate secret from any plaintext
+    value used with api_key. Must be in the same region as the delivery stream.
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "api_key_secret_kms_key_arn" {
+  description = "Optional ARN of the KMS key used to encrypt the Secrets Manager secret. Required only if the secret uses a customer managed key (CMK)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.api_key_secret_kms_key_arn == null || var.api_key_secret_kms_key_arn != ""
+    error_message = "api_key_secret_kms_key_arn must be null or a non-empty KMS key ARN."
+  }
 }
 
 variable "firehose_stream" {

--- a/modules/firehose-metrics/README.md
+++ b/modules/firehose-metrics/README.md
@@ -16,6 +16,19 @@ module "cloudwatch_firehose_metrics_coralogix" {
 }
 ```
 
+### Secrets Manager API key
+
+Optionally pass `api_key_secret_arn` instead of `api_key` so Firehose fetches the key at runtime via `SecretsManagerConfiguration`. The secret value must be JSON: `{"api_key": "..."}`. Rotating the secret then takes effect without a Terraform apply. If the secret is encrypted with a customer managed KMS key, also set `api_key_secret_kms_key_arn`. When the module creates the Firehose IAM role, it grants `secretsmanager:GetSecretValue` (and `kms:Decrypt` when a CMK ARN is set). If you pass `existing_firehose_iam`, that role must already allow those actions.
+
+```terraform
+module "cloudwatch_firehose_metrics_coralogix" {
+  source             = "coralogix/aws/coralogix//modules/firehose-metrics"
+  firehose_stream    = var.coralogix_firehose_stream_name
+  api_key_secret_arn = var.api_key_secret_arn
+  coralogix_region   = var.coralogix_region
+}
+```
+
 By default, the metric stream includes all namespaces [AWS/EC2, AWS/EBS, etc..] and metric names.
 
 

--- a/modules/firehose-metrics/main.tf
+++ b/modules/firehose-metrics/main.tf
@@ -43,6 +43,9 @@ locals {
   new_metric_stream_iam_name    = var.metric_streams_iam_custom_name != null ? var.metric_streams_iam_custom_name : "${var.firehose_stream}-cw-iam"
 
   arn_prefix = "arn:${data.aws_partition.current.partition}"
+
+  use_secrets_manager = var.api_key_secret_arn != null && var.api_key_secret_arn != ""
+  use_api_key_kms     = var.api_key_secret_kms_key_arn != null && var.api_key_secret_kms_key_arn != ""
 }
 
 data "aws_caller_identity" "current_identity" {}
@@ -212,7 +215,24 @@ resource "aws_iam_policy" "new_firehose_iam" {
           ],
           "Resource": "${aws_lambda_function.lambda_processor[0].arn}:*"
         }
-        %{else}
+        %{endif}
+        %{if local.use_secrets_manager},
+        {
+          "Effect": "Allow",
+          "Action": [
+              "secretsmanager:GetSecretValue"
+          ],
+          "Resource": "${var.api_key_secret_arn}"
+        }
+        %{endif}
+        %{if local.use_secrets_manager && local.use_api_key_kms},
+        {
+          "Effect": "Allow",
+          "Action": [
+              "kms:Decrypt"
+          ],
+          "Resource": "${var.api_key_secret_kms_key_arn}"
+        }
         %{endif}
     ]
 }
@@ -346,12 +366,21 @@ resource "aws_kinesis_firehose_delivery_stream" "coralogix_stream_metrics" {
   http_endpoint_configuration {
     url                = local.endpoint_url
     name               = "Coralogix"
-    access_key         = var.api_key
+    access_key         = local.use_secrets_manager ? null : var.api_key
     buffering_size     = 1
     buffering_interval = 60
     s3_backup_mode     = "FailedDataOnly"
     role_arn           = local.firehose_iam_role_arn
     retry_duration     = 300
+
+    dynamic "secrets_manager_configuration" {
+      for_each = local.use_secrets_manager ? [1] : []
+      content {
+        enabled    = true
+        secret_arn = var.api_key_secret_arn
+        role_arn   = local.firehose_iam_role_arn
+      }
+    }
 
     s3_configuration {
       role_arn           = local.firehose_iam_role_arn

--- a/modules/firehose-metrics/variables.tf
+++ b/modules/firehose-metrics/variables.tf
@@ -8,9 +8,37 @@ variable "coralogix_region" {
 }
 
 variable "api_key" {
-  description = "Coralogix account api key"
+  description = "Coralogix account API key. Ignored when api_key_secret_arn is set. Required unless api_key_secret_arn is provided."
   type        = string
   sensitive   = true
+  default     = null
+
+  validation {
+    condition     = (var.api_key != null && var.api_key != "") || (var.api_key_secret_arn != null && var.api_key_secret_arn != "")
+    error_message = "You must provide either api_key or api_key_secret_arn."
+  }
+}
+
+variable "api_key_secret_arn" {
+  description = <<-EOT
+    ARN of a Secrets Manager secret holding the Coralogix API key as JSON, {"api_key": "..."}.
+    When set, Firehose reads the key at runtime and api_key is ignored, so rotating the secret
+    takes effect without a Terraform apply. This must be a separate secret from any plaintext
+    value used with api_key. Must be in the same region as the delivery stream.
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "api_key_secret_kms_key_arn" {
+  description = "Optional ARN of the KMS key used to encrypt the Secrets Manager secret. Required only if the secret uses a customer managed key (CMK)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.api_key_secret_kms_key_arn == null || var.api_key_secret_kms_key_arn != ""
+    error_message = "api_key_secret_kms_key_arn must be null or a non-empty KMS key ARN."
+  }
 }
 
 variable "firehose_stream" {


### PR DESCRIPTION
# Description

Adds opt-in AWS Secrets Manager support for the Coralogix API key in `firehose-logs` and `firehose-metrics`, matching [cloudformation-coralogix-aws#239](https://github.com/coralogix/cloudformation-coralogix-aws/pull/239).

When `api_key_secret_arn` is set, Firehose uses `secrets_manager_configuration` to read a JSON secret (`{"api_key": "..."}`) at runtime instead of freezing a literal `access_key` at apply time. Optional `api_key_secret_kms_key_arn` grants `kms:Decrypt` for CMK-encrypted secrets. Existing `api_key` deployments remain unchanged.

Changelog prepared for **v4.10.0** (`feat` → minor via `.releaserc.json`).

# How Has This Been Tested?

- [x] `terraform fmt` on both modules
- [x] `terraform validate` on `modules/firehose-logs` and `modules/firehose-metrics`

# Checklist:
- [x] I have updated the relevant example in the examples directory for the module.
- [x] I have updated the relevant test file for the module.
- [ ] This change does not affect module (e.g. it's readme file change)